### PR TITLE
Revert "OY9oBr0P Add alternative subject names for *.$DOMAIN names"

### DIFF
--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -141,7 +141,6 @@ func createCert(secrets *v1.Secret, updates *v1.Secret, id string) bool {
 		}
 
 		addHost(&req, true, info.RoleName)
-		addHost(&req, true, info.RoleName+".{{.DOMAIN}}")
 		addHost(&req, true, info.RoleName+".{{.KUBERNETES_NAMESPACE}}.svc")
 		addHost(&req, true, info.RoleName+".{{.KUBERNETES_NAMESPACE}}.svc.cluster.local")
 


### PR DESCRIPTION
By default all generated certs should be for internal use and not include externally routable names. If a role requires $DOMAIN to be covered, then these should be listed explicitly in the role manifest under subject_names.

This reverts commit 6bc62fb6a2bdf2e910eca06173079e19bdd83aef.