### PR TITLE
sWAKVtIS Generate versioned main secret.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,9 +22,9 @@ func main() {
 
 	s := secret.GetSecretInterface()
 
-	create, secrets, updates := secret.GetOrCreateSecrets(s)
+	secrets, updates := secret.CreateSecrets(s)
 
 	secret.GenerateSecrets(manifest, secrets, updates)
 
-	secret.UpdateSecrets(s, secrets, create)
+	secret.UpdateSecrets(s, secrets)
 }

--- a/password/password.go
+++ b/password/password.go
@@ -1,6 +1,8 @@
 package password
 
 import (
+	"log"
+
 	"github.com/SUSE/scf-secret-generator/util"
 	"github.com/dchest/uniuri"
 	"k8s.io/api/core/v1"
@@ -14,6 +16,8 @@ func GeneratePassword(secrets, updates *v1.Secret, secretName string) {
 	if len(secrets.Data[secretKey]) > 0 {
 		return
 	}
+
+	log.Printf("- Password: %s\n", secretName)
 
 	if len(updates.Data[secretKey]) > 0 {
 		secrets.Data[secretKey] = updates.Data[secretKey]

--- a/password/password.go
+++ b/password/password.go
@@ -25,5 +25,4 @@ func GeneratePassword(secrets, updates *v1.Secret, secretName string) {
 		password := uniuri.NewLen(64)
 		secrets.Data[secretKey] = []byte(password)
 	}
-	util.MarkAsDirty(secrets)
 }

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -3,7 +3,6 @@ package password
 import (
 	"testing"
 
-	"github.com/SUSE/scf-secret-generator/util"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 )
@@ -14,7 +13,6 @@ func TestNewPasswordIsCreated(t *testing.T) {
 
 	GeneratePassword(secrets, updates, "foo")
 
-	assert.True(t, util.IsDirty(secrets), "Secrets should be dirty after adding a password")
 	assert.Len(t, secrets.Data["foo"], 64, "Generated passwords are 64 characters long")
 }
 
@@ -27,6 +25,5 @@ func TestExistingPasswordIsNotChanged(t *testing.T) {
 	secrets.Data["foo"] = data
 
 	GeneratePassword(secrets, updates, "foo")
-	assert.False(t, util.IsDirty(secrets), "Secrets should be clean because the password was not changed")
 	assert.Equal(t, data, secrets.Data["foo"], "The value of existing password should not change")
 }

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -1,9 +1,10 @@
 package secret
 
 import (
+	"fmt"
 	"log"
 	"os"
-	"regexp"
+	"strconv"
 
 	"github.com/SUSE/scf-secret-generator/model"
 	"github.com/SUSE/scf-secret-generator/password"
@@ -24,8 +25,6 @@ const SECRET_NAME = "secret"
 // The name of the secret updates stored in the kube API
 const SECRET_UPDATE_NAME = "secret-update"
 
-var secretPattern = regexp.MustCompile(SECRET_NAME+"-[0-9]+")
-
 var kubeClusterConfig = rest.InClusterConfig
 var kubeNewClient = kubernetes.NewForConfig
 var logFatal = log.Fatal
@@ -35,7 +34,7 @@ type secretInterface interface {
 	Create(*v1.Secret) (*v1.Secret, error)
 	Get(name string, options metav1.GetOptions) (*v1.Secret, error)
 	Update(*v1.Secret) (*v1.Secret, error)
-        List(opts metav1.ListOptions) (*v1.SecretList, error)
+	Delete(name string, options *metav1.DeleteOptions) error
 }
 
 var passGenerate = password.GeneratePassword
@@ -61,156 +60,96 @@ func GetSecretInterface() secretInterface {
 	return clientSet.CoreV1().Secrets(getEnv("KUBERNETES_NAMESPACE"))
 }
 
-func UpdateSecrets(s secretInterface, secrets *v1.Secret, create bool) {
-	if create {
-		util.MarkAsClean(secrets)
-		_, err := s.Create(secrets)
-		if err != nil {
-			logFatal(err)
-		}
-		log.Printf("Created `%s`\n", secrets.Name)
-	} else if util.IsDirty(secrets) {
-		util.MarkAsClean(secrets)
-		_, err := s.Update(secrets)
-		if err != nil {
-			logFatal(err)
-		}
-		log.Printf("Updated `%s`\n", secrets.Name)
-	}
-}
-
-func FindSecret(s secretInterface) (*v1.Secret, error) {
-	slist, err := s.List (metav1.ListOptions{})
+func UpdateSecrets(s secretInterface, secrets *v1.Secret) {
+	_, err := s.Create(secrets)
 	if err != nil {
-		return nil, err
+		logFatal(err)
 	}
-
-	var best v1.Secret
-	for _, s := range slist.Items {
-		if (s.Name != SECRET_NAME) && !secretPattern.MatchString(s.Name) {
-			// We allow only
-			// - SECRET_NAME exactly
-			// - names matching <SECRET_NAME>-\d+
-			// This excludes all secrets with letters after the SECRET_NAME.
-			continue
-		}
-
-		// s is now a secret which either matches
-		// SECRET_NAME-*, or is exactly SECRET_NAME.
-
-		if (best.Name == "") ||
-			(len(s.Name) > len (best.Name)) ||
-			(s.Name > best.Name) {
-			// Notes on the logic above.  It assumes that
-			// the names we deal with are of the form
-			// `foo-V` where V is an integer number
-			// without leading 0's, and the `foo` is the
-			// across all considered secrets (true, foo =
-			// SECRET_NAME)
-			//
-			// A secret is take as the new best if it
-			// either the first, or its V is greater than
-			// the V of the current best.
-			//
-			// - A longer name indicates a longer V, that
-			//   is larger (*). This relies on the `no
-			//   leading 0's` part.
-			//
-			// - For V's of the same length the lexico-
-			//   graphical order is identical to the
-			//   numeric order. This also relies on the
-			//   `no leading 0's` part.
-			//
-			// (*) The special case where the name is just
-			// `foo` is handled by this as well, as a
-			// zero-length V which is less than anything
-			// else and thus only used when nothing else
-			// is present, in line with `foo` being the
-			// last resort fallback.
-
-			best = s
-		}
-	}
-
-	if best.Name != "" {
-		return &best, nil
-	}
-	return nil, errors.NewNotFound(v1.Resource("secret"), SECRET_NAME)
+	log.Printf("Created `%s`\n", secrets.Name)
 }
 
-func GetOrCreateSecrets(s secretInterface) (create bool, secrets, updates *v1.Secret) {
+func FindPreviousSecret(s secretInterface, rv int) (*v1.Secret, error) {
+	// Args: rv is the current release revision.
+	// Logic
+	// (1) if rv-2 exists, delete it (prevent leaking of too many old entities)
+	// (2) if rv-1 exists take it
+	// (3) if secret without rv exists, take it
+	// (4) error
+
+	// / / // /// ///// //////// ///////////// /////////////////////
+
+	// (1) Delete really old entity (R-2), if it exists. We do not
+	// care about errors.
+	_ = s.Delete(SECRET_NAME + fmt.Sprintf("-%d", rv-2), &metav1.DeleteOptions{})
+
+	// (2) Look for and take R-1
+	previousSecret := SECRET_NAME + fmt.Sprintf("-%d", rv-1)
+	secret, err := s.Get(previousSecret, metav1.GetOptions{})
+	if err == nil {
+		return secret, nil
+	}
+
+	// (3) Take unversioned secret, should we have it.
+	secret, err = s.Get(SECRET_NAME, metav1.GetOptions{})
+	if err == nil {
+		return secret, nil
+	}
+
+	// (4) Neither R-1 nor unversioned available. Bail out.
+	return nil, errors.NewNotFound(v1.Resource("secret"), previousSecret)
+}
+
+func CreateSecrets(s secretInterface) (secrets, updates *v1.Secret) {
 	secretUpdateName := SECRET_UPDATE_NAME
 	secretName := SECRET_NAME
 	releaseRevision := getEnv("RELEASE_REVISION")
-	if releaseRevision != "" {
-		secretUpdateName += "-" + releaseRevision
-		secretName += "-" + releaseRevision
+
+	if releaseRevision == "" {
+		logFatal("RELEASE_REVISION is missing or empty.")
+		return nil, nil
 	}
+
+	rv, err := strconv.Atoi(releaseRevision)
+	if err != nil {
+		logFatal(err)
+		return nil, nil
+	}
+
+	secretUpdateName += "-" + releaseRevision
+	secretName += "-" + releaseRevision
 
 	log.Printf("Checking for chart-provided `%s`\n", secretUpdateName)
 
 	// secret updates *must* exist
-	updates, err := s.Get(secretUpdateName, metav1.GetOptions{})
+	updates, err = s.Get(secretUpdateName, metav1.GetOptions{})
 	if err != nil {
 		logFatal(err)
-		return false, nil, nil
+		return nil, nil
 	}
 
-	log.Println("Now ready to generate secrets")
-
-	// check for existing secret, initialize a new Secret if not found
-	secrets, err = FindSecret(s)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			log.Printf("No previous secret found, will create `%s`\n",
-				secretName)
-
-			create = true
-			secrets = &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: secretName,
-				},
-				Data: map[string][]byte{},
-			}
-		} else {
-			logFatal(err)
-			return false, nil, nil
-		}
-	} else {
-		if secrets.Name != secretName {
-			// The structure was imported and the
-			// destination to write to is different than
-			// what we got (per the names). Force creation.
-
-			log.Printf("Imported previous secret `%s`, will create `%s`\n",
-				secrets.Name, secretName)
-
-			create = true
-
-			// Note that the imported structure has its
-			// field `ResourceVersion` set. That makes it
-			// unsuitable for use with `Create`.  `Create`
-			// actually rejects it and aborts the process.
-
-			// The field is noted as read-only, we cannot
-			// unset it.  We deal with the situation by
-			// creating a fresh structure, i.e. without
-			// `ResourceVersion` set, and give it a copy
-			// of the imported data (and the destination
-			// name, of course).
-			newsecrets := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: secretName,
-				},
-				Data: secrets.Data,
-			}
-			secrets = newsecrets
-		} else {
-			log.Printf("Imported secret `%s`, will update\n",
-				secrets.Name)
-		}
+	// We always create a new secret
+	secrets = &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Data: map[string][]byte{},
 	}
 
+	log.Println("Checking for previous secret")
+
+	// Check for existing secret to use as baseline
+	previousSecrets, err := FindPreviousSecret(s, rv)
+	if err != nil && !errors.IsNotFound(err) {
+		logFatal(err)
+		return nil, nil
+	}
+	// Here: err == nil || errors.IsNotFound(err)
+	if previousSecrets != nil {
+		log.Printf("Importing previous secret `%s`\n", previousSecrets.Name)
+		secrets.Data = previousSecrets.Data
+	}
+
+	log.Printf("Fill secret `%s`\n", secrets.Name)
 	return
 }
 
@@ -258,7 +197,6 @@ func updateVariable(secrets, updates *v1.Secret, configVar *model.ConfigurationV
 	name := util.ConvertNameToKey(configVar.Name)
 	if len(secrets.Data[name]) == 0 && len(updates.Data[name]) > 0 {
 		secrets.Data[name] = updates.Data[name]
-		util.MarkAsDirty(secrets)
 	}
 }
 
@@ -269,7 +207,6 @@ func migrateRenamedVariable(secrets *v1.Secret, configVar *model.ConfigurationVa
 			previousValue := secrets.Data[util.ConvertNameToKey(previousName)]
 			if len(previousValue) > 0 {
 				secrets.Data[name] = previousValue
-				util.MarkAsDirty(secrets)
 				return
 			}
 		}

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -80,10 +80,10 @@ func FindPreviousSecret(s secretInterface, rv int) (*v1.Secret, error) {
 
 	// (1) Delete really old entity (R-2), if it exists. We do not
 	// care about errors.
-	_ = s.Delete(SECRET_NAME + fmt.Sprintf("-%d", rv-2), &metav1.DeleteOptions{})
+	_ = s.Delete(fmt.Sprintf("%s-%d", SECRET_NAME, rv-2), &metav1.DeleteOptions{})
 
 	// (2) Look for and take R-1
-	previousSecret := SECRET_NAME + fmt.Sprintf("-%d", rv-1)
+	previousSecret := fmt.Sprintf("%s-%d", SECRET_NAME, rv-1)
 	secret, err := s.Get(previousSecret, metav1.GetOptions{})
 	if err == nil {
 		return secret, nil

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"log"
 	"os"
+	"regexp"
 
 	"github.com/SUSE/scf-secret-generator/model"
 	"github.com/SUSE/scf-secret-generator/password"
@@ -23,6 +24,8 @@ const SECRET_NAME = "secret"
 // The name of the secret updates stored in the kube API
 const SECRET_UPDATE_NAME = "secret-update"
 
+var secretPattern = regexp.MustCompile(SECRET_NAME+"-[0-9]+")
+
 var kubeClusterConfig = rest.InClusterConfig
 var kubeNewClient = kubernetes.NewForConfig
 var logFatal = log.Fatal
@@ -32,6 +35,7 @@ type secretInterface interface {
 	Create(*v1.Secret) (*v1.Secret, error)
 	Get(name string, options metav1.GetOptions) (*v1.Secret, error)
 	Update(*v1.Secret) (*v1.Secret, error)
+        List(opts metav1.ListOptions) (*v1.SecretList, error)
 }
 
 var passGenerate = password.GeneratePassword
@@ -64,23 +68,86 @@ func UpdateSecrets(s secretInterface, secrets *v1.Secret, create bool) {
 		if err != nil {
 			logFatal(err)
 		}
-		log.Println("Created `secret`")
+		log.Printf("Created `%s`\n", secrets.Name)
 	} else if util.IsDirty(secrets) {
 		util.MarkAsClean(secrets)
 		_, err := s.Update(secrets)
 		if err != nil {
 			logFatal(err)
 		}
-		log.Println("Updated `secret`")
+		log.Printf("Updated `%s`\n", secrets.Name)
 	}
+}
+
+func FindSecret(s secretInterface) (*v1.Secret, error) {
+	slist, err := s.List (metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var best v1.Secret
+	for _, s := range slist.Items {
+		if (s.Name != SECRET_NAME) && !secretPattern.MatchString(s.Name) {
+			// We allow only
+			// - SECRET_NAME exactly
+			// - names matching <SECRET_NAME>-\d+
+			// This excludes all secrets with letters after the SECRET_NAME.
+			continue
+		}
+
+		// s is now a secret which either matches
+		// SECRET_NAME-*, or is exactly SECRET_NAME.
+
+		if (best.Name == "") ||
+			(len(s.Name) > len (best.Name)) ||
+			(s.Name > best.Name) {
+			// Notes on the logic above.  It assumes that
+			// the names we deal with are of the form
+			// `foo-V` where V is an integer number
+			// without leading 0's, and the `foo` is the
+			// across all considered secrets (true, foo =
+			// SECRET_NAME)
+			//
+			// A secret is take as the new best if it
+			// either the first, or its V is greater than
+			// the V of the current best.
+			//
+			// - A longer name indicates a longer V, that
+			//   is larger (*). This relies on the `no
+			//   leading 0's` part.
+			//
+			// - For V's of the same length the lexico-
+			//   graphical order is identical to the
+			//   numeric order. This also relies on the
+			//   `no leading 0's` part.
+			//
+			// (*) The special case where the name is just
+			// `foo` is handled by this as well, as a
+			// zero-length V which is less than anything
+			// else and thus only used when nothing else
+			// is present, in line with `foo` being the
+			// last resort fallback.
+
+			best = s
+		}
+	}
+
+	if best.Name != "" {
+		return &best, nil
+	}
+	return nil, errors.NewNotFound(v1.Resource("secret"), SECRET_NAME)
 }
 
 func GetOrCreateSecrets(s secretInterface) (create bool, secrets, updates *v1.Secret) {
 	secretUpdateName := SECRET_UPDATE_NAME
+	secretName := SECRET_NAME
 	releaseRevision := getEnv("RELEASE_REVISION")
 	if releaseRevision != "" {
 		secretUpdateName += "-" + releaseRevision
+		secretName += "-" + releaseRevision
 	}
+
+	log.Printf("Checking for chart-provided `%s`\n", secretUpdateName)
 
 	// secret updates *must* exist
 	updates, err := s.Get(secretUpdateName, metav1.GetOptions{})
@@ -89,22 +156,58 @@ func GetOrCreateSecrets(s secretInterface) (create bool, secrets, updates *v1.Se
 		return false, nil, nil
 	}
 
+	log.Println("Now ready to generate secrets")
+
 	// check for existing secret, initialize a new Secret if not found
-	secrets, err = s.Get(SECRET_NAME, metav1.GetOptions{})
+	secrets, err = FindSecret(s)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Println("`secret` not found, creating")
-			create = true
+			log.Printf("No previous secret found, will create `%s`\n",
+				secretName)
 
+			create = true
 			secrets = &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: SECRET_NAME,
+					Name: secretName,
 				},
 				Data: map[string][]byte{},
 			}
 		} else {
 			logFatal(err)
 			return false, nil, nil
+		}
+	} else {
+		if secrets.Name != secretName {
+			// The structure was imported and the
+			// destination to write to is different than
+			// what we got (per the names). Force creation.
+
+			log.Printf("Imported previous secret `%s`, will create `%s`\n",
+				secrets.Name, secretName)
+
+			create = true
+
+			// Note that the imported structure has its
+			// field `ResourceVersion` set. That makes it
+			// unsuitable for use with `Create`.  `Create`
+			// actually rejects it and aborts the process.
+
+			// The field is noted as read-only, we cannot
+			// unset it.  We deal with the situation by
+			// creating a fresh structure, i.e. without
+			// `ResourceVersion` set, and give it a copy
+			// of the imported data (and the destination
+			// name, of course).
+			newsecrets := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: secretName,
+				},
+				Data: secrets.Data,
+			}
+			secrets = newsecrets
+		} else {
+			log.Printf("Imported secret `%s`, will update\n",
+				secrets.Name)
 		}
 	}
 
@@ -114,7 +217,10 @@ func GetOrCreateSecrets(s secretInterface) (create bool, secrets, updates *v1.Se
 func GenerateSecrets(manifest model.Manifest, secrets, updates *v1.Secret) {
 	sshKeys := make(map[string]ssh.SSHKey)
 
-	// go over the list of variables and run the appropriate generator function
+	log.Println("Generate Passwords ...")
+
+	// go over the list of manifest variables and run the
+	// appropriate generator function
 	for _, configVar := range manifest.Configuration.Variables {
 		if configVar.Secret {
 			migrateRenamedVariable(secrets, configVar)
@@ -135,11 +241,17 @@ func GenerateSecrets(manifest model.Manifest, secrets, updates *v1.Secret) {
 		}
 	}
 
+	log.Println("Generate SSH ...")
+
 	for _, key := range sshKeys {
 		sshKeyGenerate(secrets, updates, key)
 	}
 
+	log.Println("Generate SSL ...")
+
 	generateSSLCerts(secrets, updates)
+
+	log.Println("Done with generation")
 }
 
 func updateVariable(secrets, updates *v1.Secret, configVar *model.ConfigurationVariable) {

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -28,6 +28,8 @@ func GenerateSSHKey(secrets, updates *v1.Secret, key SSHKey) {
 		return
 	}
 
+	log.Printf("- SSH priK: %s\n", key.PrivateKey)
+
 	// Prefer user supplied update data over generating the keys ourselves
 	if len(updates.Data[secretKey]) > 0 {
 		if len(updates.Data[fingerprintKey]) == 0 {

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -37,7 +37,6 @@ func GenerateSSHKey(secrets, updates *v1.Secret, key SSHKey) {
 		}
 		secrets.Data[secretKey] = updates.Data[secretKey]
 		secrets.Data[fingerprintKey] = updates.Data[fingerprintKey]
-		util.MarkAsDirty(secrets)
 		return
 	}
 	if len(updates.Data[fingerprintKey]) > 0 {
@@ -65,7 +64,6 @@ func GenerateSSHKey(secrets, updates *v1.Secret, key SSHKey) {
 	// PEM encode private key
 	secrets.Data[secretKey] = pem.EncodeToMemory(privateBlock)
 	secrets.Data[fingerprintKey] = []byte(ssh.FingerprintLegacyMD5(public))
-	util.MarkAsDirty(secrets)
 }
 
 func RecordSSHKeyInfo(keys map[string]SSHKey, configVar *model.ConfigurationVariable) {

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/SUSE/scf-secret-generator/model"
-	"github.com/SUSE/scf-secret-generator/util"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 )
@@ -27,8 +26,6 @@ func TestNewKeyIsCreated(t *testing.T) {
 	}
 
 	GenerateSSHKey(secrets, updates, key)
-
-	assert.True(t, util.IsDirty(secrets))
 
 	assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
 	assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
@@ -57,7 +54,6 @@ func TestExistingKeyIsNotChanged(t *testing.T) {
 	}
 
 	GenerateSSHKey(secrets, updates, key)
-	assert.False(t, util.IsDirty(secrets))
 	assert.Equal(t, fooData, secrets.Data["foo"])
 	assert.Equal(t, barData, secrets.Data["bar"])
 }

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -117,7 +117,6 @@ func createCAImpl(secrets, updates *v1.Secret, id string) {
 
 	secrets.Data[info.PrivateKeyName] = info.PrivateKey
 	secrets.Data[info.CertificateName] = info.Certificate
-	util.MarkAsDirty(secrets)
 
 	certInfo[id] = info
 }
@@ -218,7 +217,6 @@ func createCertImpl(secrets, updates *v1.Secret, id string) {
 
 	secrets.Data[info.PrivateKeyName] = info.PrivateKey
 	secrets.Data[info.CertificateName] = info.Certificate
-	util.MarkAsDirty(secrets)
 	certInfo[id] = info
 }
 
@@ -232,7 +230,6 @@ func updateCertImpl(secrets, updates *v1.Secret, id string) bool {
 		}
 		secrets.Data[info.PrivateKeyName] = updates.Data[info.PrivateKeyName]
 		secrets.Data[info.CertificateName] = updates.Data[info.CertificateName]
-		util.MarkAsDirty(secrets)
 
 		// keep cert info in case this is a CA
 		info.PrivateKey = secrets.Data[info.PrivateKeyName]

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -2,6 +2,7 @@ package ssl
 
 import (
 	"fmt"
+	glog "log"
 	"os"
 	"time"
 
@@ -64,6 +65,8 @@ func GenerateCerts(secrets, updates *v1.Secret) {
 	// generate all the CAs first because they are needed to sign the certs
 	for id, info := range certInfo {
 		if info.IsAuthority {
+			glog.Printf("- SSL CA: %s\n", id)
+
 			createCA(secrets, updates, id)
 		}
 	}
@@ -71,6 +74,9 @@ func GenerateCerts(secrets, updates *v1.Secret) {
 		if info.IsAuthority {
 			continue
 		}
+
+		glog.Printf("- SSL CRT: %s\n", id)
+
 		if len(info.SubjectNames) == 0 && info.RoleName == "" {
 			fmt.Fprintf(os.Stderr, "Warning: certificate %s has no names\n", info.CertificateName)
 		}

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/SUSE/scf-secret-generator/model"
-	"github.com/SUSE/scf-secret-generator/util"
 	"github.com/cloudflare/cfssl/csr"
 	cferr "github.com/cloudflare/cfssl/errors"
 	"github.com/stretchr/testify/assert"
@@ -317,7 +316,6 @@ func TestCreateCA(t *testing.T) {
 
 		createCAImpl(secrets, updates, CERT_ID)
 
-		assert.False(t, util.IsDirty(secrets))
 		assert.Equal(t, []byte("private-key-data"), certInfo[CERT_ID].PrivateKey)
 		assert.Equal(t, []byte("certificate-data"), certInfo[CERT_ID].Certificate)
 	})
@@ -350,7 +348,6 @@ func TestCreateCA(t *testing.T) {
 
 		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		createCAImpl(secrets, updates, CERT_ID)
-		assert.True(t, util.IsDirty(secrets))
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName], []byte{})
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].CertificateName], []byte{})
 	})
@@ -407,7 +404,6 @@ func TestCreateCert(t *testing.T) {
 			CertificateName: "certificate-name",
 		}
 		createCertImpl(secrets, updates, CERT_ID)
-		assert.False(t, util.IsDirty(secrets))
 	})
 
 	t.Run("If updateCert() is true, return true", func(t *testing.T) {
@@ -553,7 +549,6 @@ func TestCreateCert(t *testing.T) {
 		}
 		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		createCertImpl(secrets, updates, CERT_ID)
-		assert.True(t, util.IsDirty(secrets))
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName], []byte{})
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].CertificateName], []byte{})
 		_, err := tls.X509KeyPair(secrets.Data[certInfo[CERT_ID].CertificateName],
@@ -588,7 +583,6 @@ func TestCreateCert(t *testing.T) {
 		}
 		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		createCertImpl(secrets, updates, CERT_ID)
-		assert.True(t, util.IsDirty(secrets))
 		assert.NotEmpty(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName])
 		assert.NotEmpty(t, secrets.Data[certInfo[CERT_ID].CertificateName])
 

--- a/util/util.go
+++ b/util/util.go
@@ -6,12 +6,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
-
-	"k8s.io/api/core/v1"
 )
-
-// Key used to show that the secrets have been modified
-const DIRTY_SECRET = "this-secret-is-dirty"
 
 var env map[string]string
 
@@ -43,17 +38,4 @@ func ExpandEnvTemplates(str string) string {
 	buf := &bytes.Buffer{}
 	t.Execute(buf, env)
 	return buf.String()
-}
-
-func IsDirty(secrets *v1.Secret) bool {
-	_, exists := secrets.Data[DIRTY_SECRET]
-	return exists
-}
-
-func MarkAsClean(secrets *v1.Secret) {
-	delete(secrets.Data, DIRTY_SECRET)
-}
-
-func MarkAsDirty(secrets *v1.Secret) {
-	secrets.Data[DIRTY_SECRET] = []byte("")
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"k8s.io/api/core/v1"
 )
 
 type MockLog struct {
@@ -71,20 +70,4 @@ func TestExpandEnvTemplates(t *testing.T) {
 			"Can't parse templates in '%s': %s",
 			[]interface{}{"{{.bad", errors.New("template: :1: unclosed action")})
 	})
-}
-
-func TestDirtySecrets(t *testing.T) {
-	t.Parallel()
-
-	secrets := &v1.Secret{Data: map[string][]byte{}}
-	assert.False(t, IsDirty(secrets))
-
-	MarkAsClean(secrets)
-	assert.False(t, IsDirty(secrets))
-
-	MarkAsDirty(secrets)
-	assert.True(t, IsDirty(secrets))
-
-	MarkAsClean(secrets)
-	assert.False(t, IsDirty(secrets))
 }


### PR DESCRIPTION
Ref: https://trello.com/c/sWAKVtIS/551-3-use-versioned-secrets-to-avoid-race-condition
For all related PRs (fissile, scf-secret-generator, uaa-fissile-release, scf)

- Log output added to have insight into the stages the generator is
  going through, and the secrets it is searching for, accessing, and
  writing.

- Replaced simple Get of a possible previous secret with List of all,
  plus filtering for candidates (Pattern foo|foo-\d+).

- Note that with writing a versioned secret the destination usually is
  not the same as the imported previous secret, forcing creation,
  instead of update.