### PR TITLE
Redo how secrets are generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
-all: test build
+.PHONY: all format lint vet build test tools
 
-.PHONY: test build
+all: format lint build test vet
+
+format:
+	make/format
+
+lint:
+	make/lint
+
+vet:
+	make/vet
+
+tools:
+	make/tools
 
 test:
 	go test -race -cover $$(go list -f '{{ .ImportPath }}' ./... | grep -v vendor)

--- a/main.go
+++ b/main.go
@@ -20,11 +20,13 @@ func main() {
 
 	manifest := model.GetManifest(os.Args[1])
 
+	c := secret.GetConfigMapInterface()
 	s := secret.GetSecretInterface()
 
-	secrets, updates := secret.CreateSecrets(s)
+	configMap := secret.GetSecretConfig(c)
+	secrets := secret.GetSecrets(s, configMap)
 
-	secret.GenerateSecrets(manifest, secrets, updates)
+	secret.GenerateSecrets(manifest, secrets, configMap)
 
-	secret.UpdateSecrets(s, secrets)
+	secret.UpdateSecrets(s, secrets, c, configMap)
 }

--- a/main.go
+++ b/main.go
@@ -18,15 +18,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	sg := secrets.NewSecretGenerator()
+
 	manifest := model.GetManifest(os.Args[1])
 
-	c := secrets.GetConfigMapInterface()
-	s := secrets.GetSecretInterface()
+	c := sg.GetConfigMapInterface()
+	s := sg.GetSecretInterface()
 
-	configMap := secrets.GetSecretConfig(c)
-	secret := secrets.GetSecret(s, configMap)
+	configMap := sg.GetSecretConfig(c)
+	secret := sg.GetSecret(s, configMap)
 	if secret != nil {
-		secrets.GenerateSecret(manifest, secret, configMap)
-		secrets.UpdateSecret(s, secret, c, configMap)
+		sg.GenerateSecret(manifest, secret, configMap)
+		sg.UpdateSecret(s, secret, c, configMap)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ func main() {
 
 	configMap := secret.GetSecretConfig(c)
 	secrets := secret.GetSecrets(s, configMap)
-
-	secret.GenerateSecrets(manifest, secrets, configMap)
-
-	secret.UpdateSecrets(s, secrets, c, configMap)
+	if secrets != nil {
+		secret.GenerateSecrets(manifest, secrets, configMap)
+		secret.UpdateSecrets(s, secrets, c, configMap)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/SUSE/scf-secret-generator/model"
-	"github.com/SUSE/scf-secret-generator/secret"
+	"github.com/SUSE/scf-secret-generator/secrets"
 )
 
 func printHelp() {
@@ -20,13 +20,13 @@ func main() {
 
 	manifest := model.GetManifest(os.Args[1])
 
-	c := secret.GetConfigMapInterface()
-	s := secret.GetSecretInterface()
+	c := secrets.GetConfigMapInterface()
+	s := secrets.GetSecretInterface()
 
-	configMap := secret.GetSecretConfig(c)
-	secrets := secret.GetSecrets(s, configMap)
-	if secrets != nil {
-		secret.GenerateSecrets(manifest, secrets, configMap)
-		secret.UpdateSecrets(s, secrets, c, configMap)
+	configMap := secrets.GetSecretConfig(c)
+	secret := secrets.GetSecret(s, configMap)
+	if secret != nil {
+		secrets.GenerateSecret(manifest, secret, configMap)
+		secrets.UpdateSecret(s, secret, c, configMap)
 	}
 }

--- a/make/format
+++ b/make/format
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -o errexit
+
+. make/include/colors.sh
+
+printf "%b==> Formatting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
+ISSUES=$(mktemp)
+
+trap "cat ${ISSUES} ; rm -f ${ISSUES}" EXIT
+
+go list -f '{{ .Dir }}' ./... | sed '/\/vendor\//d' | while read DIR; do
+    goimports -d -e "${DIR}"/*.go >> "${ISSUES}"
+done
+
+printf "%b" "${NO_COLOR}"
+
+test ! -s "${ISSUES}"

--- a/make/include/colors.sh
+++ b/make/include/colors.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+NO_COLOR='\033[0m'
+OK_COLOR='\033[32;01m'
+ERROR_COLOR='\033[31;01m'
+WARN_COLOR='\033[33;01m'

--- a/make/include/versioning
+++ b/make/include/versioning
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set +o errexit +o nounset
+
+test -n "${XTRACE}" && set -o xtrace
+
+set -o errexit -o nounset
+
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+if [ -e ${GIT_ROOT}/.version ]; then
+ARTIFACT_NAME=$(awk -F, '{ print $1 }' ${GIT_ROOT}/.version)
+GIT_BRANCH=$(awk -F, '{ print $2 }' ${GIT_ROOT}/.version)
+GIT_DESCRIBE=$(awk -F, '{ print $3 }' ${GIT_ROOT}/.version)
+fi
+
+GIT_DESCRIBE=${GIT_DESCRIBE:-$(git describe --tags --long)}
+GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD)}
+
+GIT_TAG=${GIT_TAG:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $1 }' )}
+GIT_COMMITS=${GIT_COMMITS:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $2 }' )}
+GIT_SHA=${GIT_SHA:-$(echo ${GIT_DESCRIBE} | awk -F - '{ print $3 }' )}
+
+ARTIFACT_NAME=${ARTIFACT_NAME:-$(basename $(git config --get remote.origin.url) .git | sed s/^scf-//)}
+ARTIFACT_VERSION=${GIT_TAG}+${GIT_COMMITS}.${GIT_SHA}
+
+APP_VERSION=${ARTIFACT_NAME}-${ARTIFACT_VERSION}
+
+set +o errexit +o nounset +o xtrace

--- a/make/lint
+++ b/make/lint
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -o errexit
+
+. make/include/colors.sh
+
+printf "%b==> Linting%b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
+ISSUES=$(mktemp)
+
+trap "cat ${ISSUES} ; rm -f ${ISSUES}" EXIT
+
+go list -f '{{ .Dir }}' ./... | sed '\@/vendor/@d ' | while read DIR; do
+    golint $(ls "${DIR}"/*.go | grep -v _generated.go) >> "${ISSUES}"
+done
+
+printf "%b" "${NO_COLOR}"
+
+test ! -s "${ISSUES}"

--- a/make/tools
+++ b/make/tools
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+
+go get -u golang.org/x/tools/cmd/goimports
+go get -u github.com/golang/lint/golint
+go get -u github.com/AlekSi/gocov-xml
+go get -u github.com/tools/godep

--- a/make/vet
+++ b/make/vet
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -o errexit
+
+. make/include/colors.sh
+
+printf "%b==> Vetting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
+go vet $(go list -f '{{ .ImportPath }}' ./... | sed '\@/vendor/@d')
+
+printf "%b" "${NO_COLOR}"

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -65,6 +65,7 @@ type ConfigurationVariable struct {
 	Internal      bool                            `yaml:"internal,omitempty"`
 	Secret        bool                            `yaml:"secret,omitempty"`
 	Required      bool                            `yaml:"required,omitempty"`
+	Immutable     bool                            `yaml:"immutable,omitempty"`
 }
 
 // CVType is the type of the configuration variable; see the constants below

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -92,6 +92,7 @@ type Manifest struct {
 var logFatal = log.Fatal
 var fileReader = ioutil.ReadFile
 
+// GetManifest loads a manifest from file
 func GetManifest(name string) (manifest Manifest) {
 	manifestFile, err := fileReader(name)
 	if err != nil {

--- a/password/password.go
+++ b/password/password.go
@@ -9,19 +9,13 @@ import (
 )
 
 // GeneratePassword generates a password for `secretName` if it doesn't already exist
-func GeneratePassword(secrets, updates *v1.Secret, secretName string) {
+func GeneratePassword(secrets *v1.Secret, secretName string) {
 	secretKey := util.ConvertNameToKey(secretName)
 
 	// Only create keys, don't update them
-	if len(secrets.Data[secretKey]) > 0 {
-		return
-	}
+	if len(secrets.Data[secretKey]) == 0 {
+		log.Printf("- Password: %s\n", secretName)
 
-	log.Printf("- Password: %s\n", secretName)
-
-	if len(updates.Data[secretKey]) > 0 {
-		secrets.Data[secretKey] = updates.Data[secretKey]
-	} else {
 		password := uniuri.NewLen(64)
 		secrets.Data[secretKey] = []byte(password)
 	}

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestNewPasswordIsCreated(t *testing.T) {
 	secrets := &v1.Secret{Data: map[string][]byte{}}
-	updates := &v1.Secret{Data: map[string][]byte{}}
 
-	GeneratePassword(secrets, updates, "foo")
+	GeneratePassword(secrets, "foo")
 
 	assert.Len(t, secrets.Data["foo"], 64, "Generated passwords are 64 characters long")
 }
@@ -20,10 +19,9 @@ func TestExistingPasswordIsNotChanged(t *testing.T) {
 	data := []byte("bar")
 
 	secrets := &v1.Secret{Data: map[string][]byte{}}
-	updates := &v1.Secret{Data: map[string][]byte{}}
 
 	secrets.Data["foo"] = data
 
-	GeneratePassword(secrets, updates, "foo")
+	GeneratePassword(secrets, "foo")
 	assert.Equal(t, data, secrets.Data["foo"], "The value of existing password should not change")
 }

--- a/secret/secret_test.go
+++ b/secret/secret_test.go
@@ -58,7 +58,7 @@ func (m *MockSecretInterface) Get(name string, options metav1.GetOptions) (*v1.S
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
 			},
-			Data: map[string][]byte{},
+			Data: map[string][]byte{"dummy": []byte("data")},
 		}
 
 		secret.Data[name] = []byte(name)
@@ -101,7 +101,7 @@ func TestGetSecretConfig(t *testing.T) {
 	configMap := GetSecretConfig(&c)
 
 	if assert.NotNil(t, configMap) {
-		assert.Equal(t, SECRETS_CONFIGMAP_NAME, configMap.ObjectMeta.Name)
+		assert.Equal(t, SECRETS_CONFIGMAP_NAME, configMap.Name)
 		assert.Equal(t, LEGACY_SECRETS_NAME, configMap.Data[CURRENT_SECRETS_NAME])
 		assert.Equal(t, "0", configMap.Data[CURRENT_SECRETS_GENERATION])
 	}
@@ -121,10 +121,10 @@ func TestGetSecrets(t *testing.T) {
 		secrets := GetSecrets(&s, configMap)
 
 		if assert.NotNil(t, secrets) {
-			assert.Equal(t, "", secrets.ObjectMeta.Name)
+			assert.Empty(t, secrets.Name)
 		}
-		// Current secrets name being empty signals that the config map must be created, not updated
-		assert.Equal(t, "", configMap.Data[CURRENT_SECRETS_NAME])
+		// Current secrets name being empty signals that the configmap must be created, not updated
+		assert.Empty(t, configMap.Data[CURRENT_SECRETS_NAME])
 	})
 
 	t.Run("ConfigMap names a secret that doesn't exist", func(t *testing.T) {
@@ -161,7 +161,9 @@ func TestGetSecrets(t *testing.T) {
 		secrets := GetSecrets(&s, configMap)
 
 		if assert.NotNil(t, secrets) {
-			assert.Equal(t, "current-secret", secrets.ObjectMeta.Name)
+			// Name should be empty, only Data should be copied
+			assert.Empty(t, secrets.Name)
+			assert.Equal(t, []byte("data"), secrets.Data["dummy"])
 		}
 	})
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -30,11 +30,13 @@ const previousSecretName = "previous-secrets-name"
 var kubeClusterConfig = rest.InClusterConfig
 var kubeNewClient = kubernetes.NewForConfig
 
+// SecretGenerator contains all global state for creating new secrets
 type SecretGenerator struct {
 	Fatal  func(v ...interface{})
 	Getenv func(key string) string
 }
 
+// NewSecretGenerator returns an instance of the SecretGenerator
 func NewSecretGenerator() SecretGenerator {
 	return SecretGenerator{
 		Fatal:  log.Fatal,

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -1,4 +1,4 @@
-package secret
+package secrets
 
 import (
 	"fmt"
@@ -18,28 +18,30 @@ import (
 )
 
 // The unversioned name of the secret used by legacy versions of the secrets generator
-const LEGACY_SECRETS_NAME = "secret"
+const legacySecretName = "secret"
 
 // The name of the secrets configmap
-const SECRETS_CONFIGMAP_NAME = "secrets-config"
+const secretsConfigMapName = "secrets-config"
 
-const CURRENT_SECRETS_NAME = "current-secrets-name"
-const CURRENT_SECRETS_GENERATION = "current-secrets-generation"
-const PREVIOUS_SECRETS_NAME = "previous-secrets-name"
+const currentSecretName = "current-secrets-name"
+const currentSecretGeneration = "current-secrets-generation"
+const previousSecretName = "previous-secrets-name"
 
 var kubeClusterConfig = rest.InClusterConfig
 var kubeNewClient = kubernetes.NewForConfig
 var logFatal = log.Fatal
 var getEnv = os.Getenv
 
-type configMapInterface interface {
+// ConfigMapInterface is a subset of v1.ConfigMapInterface
+type ConfigMapInterface interface {
 	Create(*v1.ConfigMap) (*v1.ConfigMap, error)
 	Get(name string, options metav1.GetOptions) (*v1.ConfigMap, error)
 	Update(*v1.ConfigMap) (*v1.ConfigMap, error)
 	Delete(name string, options *metav1.DeleteOptions) error
 }
 
-type secretInterface interface {
+// SecretInterface is a subset of v1.SecretInterface
+type SecretInterface interface {
 	Create(*v1.Secret) (*v1.Secret, error)
 	Get(name string, options metav1.GetOptions) (*v1.Secret, error)
 	Update(*v1.Secret) (*v1.Secret, error)
@@ -56,7 +58,8 @@ func kubeClientset() (*kubernetes.Clientset, error) {
 	return clientset, err
 }
 
-func GetConfigMapInterface() configMapInterface {
+// GetConfigMapInterface returns a configmap interface for the KUBERNETES_NAMESPACE
+func GetConfigMapInterface() ConfigMapInterface {
 	clientset, err := kubeClientset()
 	if err != nil {
 		logFatal(err)
@@ -65,7 +68,8 @@ func GetConfigMapInterface() configMapInterface {
 	return clientset.CoreV1().ConfigMaps(getEnv("KUBERNETES_NAMESPACE"))
 }
 
-func GetSecretInterface() secretInterface {
+// GetSecretInterface returns a secrets interface for the KUBERNETES_NAMESPACE
+func GetSecretInterface() SecretInterface {
 	clientset, err := kubeClientset()
 	if err != nil {
 		logFatal(err)
@@ -74,23 +78,26 @@ func GetSecretInterface() secretInterface {
 	return clientset.CoreV1().Secrets(getEnv("KUBERNETES_NAMESPACE"))
 }
 
-func GetSecretConfig(c configMapInterface) *v1.ConfigMap {
-	configMap, err := c.Get(SECRETS_CONFIGMAP_NAME, metav1.GetOptions{})
+// GetSecretConfig returns the configmap containing the secrets configuration
+func GetSecretConfig(c ConfigMapInterface) *v1.ConfigMap {
+	configMap, err := c.Get(secretsConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		configMap = &v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: SECRETS_CONFIGMAP_NAME,
+				Name: secretsConfigMapName,
 			},
 			Data: map[string]string{},
 		}
-		configMap.Data[CURRENT_SECRETS_NAME] = LEGACY_SECRETS_NAME
-		configMap.Data[CURRENT_SECRETS_GENERATION] = "0"
+		configMap.Data[currentSecretName] = legacySecretName
+		configMap.Data[currentSecretGeneration] = "0"
 	}
 	return configMap
 }
 
-func GetSecrets(s secretInterface, configMap *v1.ConfigMap) *v1.Secret {
-	currentName := configMap.Data[CURRENT_SECRETS_NAME]
+// GetSecret returns a new Secret object initialized with the data
+// of the currently active secrets
+func GetSecret(s SecretInterface, configMap *v1.ConfigMap) *v1.Secret {
+	currentName := configMap.Data[currentSecretName]
 
 	newName := getEnv("KUBE_SECRETS_GENERATION_NAME")
 	if newName == "" {
@@ -102,37 +109,40 @@ func GetSecrets(s secretInterface, configMap *v1.ConfigMap) *v1.Secret {
 		return nil
 	}
 
-	newSecrets := &v1.Secret{
+	newSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: newName,
 		},
 		Data: map[string][]byte{},
 	}
 
-	currentSecrets, err := s.Get(currentName, metav1.GetOptions{})
+	currentSecret, err := s.Get(currentName, metav1.GetOptions{})
 	if err == nil {
-		newSecrets.Data = currentSecrets.Data
+		newSecret.Data = currentSecret.Data
 	} else {
-		if currentName != LEGACY_SECRETS_NAME {
+		if currentName != legacySecretName {
 			logFatal(fmt.Sprintf("Cannot get previous version of secrets using name '%s'.", currentName))
 			return nil
 		}
 		// This is a new installation, so make sure the configmap is created, not updated
-		configMap.Data[CURRENT_SECRETS_NAME] = ""
+		configMap.Data[currentSecretName] = ""
 	}
 
-	return newSecrets
+	return newSecret
 }
 
-func GenerateSecrets(manifest model.Manifest, secrets *v1.Secret, configMap *v1.ConfigMap) {
+// GenerateSecret will generate all secrets defined in the manifest that don't already exist
+// in the secret. If secrets rotation is triggered, then all secrets not marked as immutable
+// in the manifest will be regenerated.
+func GenerateSecret(manifest model.Manifest, secrets *v1.Secret, configMap *v1.ConfigMap) {
 	secretsGeneration := getEnv("KUBE_SECRETS_GENERATION_COUNTER")
 	if secretsGeneration == "" {
 		logFatal("KUBE_SECRETS_GENERATION_COUNTER is missing or empty.")
 		return
 	}
 
-	if secretsGeneration != configMap.Data[CURRENT_SECRETS_GENERATION] {
-		log.Printf("Rotating secrets; generation '%s' -> '%s'\n", configMap.Data[CURRENT_SECRETS_GENERATION], secretsGeneration)
+	if secretsGeneration != configMap.Data[currentSecretGeneration] {
+		log.Printf("Rotating secrets; generation '%s' -> '%s'\n", configMap.Data[currentSecretGeneration], secretsGeneration)
 		for name := range secrets.Data {
 			rotate := true
 			for _, configVar := range manifest.Configuration.Variables {
@@ -146,10 +156,10 @@ func GenerateSecrets(manifest model.Manifest, secrets *v1.Secret, configMap *v1.
 				delete(secrets.Data, name)
 			}
 		}
-		configMap.Data[CURRENT_SECRETS_GENERATION] = secretsGeneration
+		configMap.Data[currentSecretGeneration] = secretsGeneration
 	}
 
-	sshKeys := make(map[string]ssh.SSHKey)
+	sshKeys := make(map[string]ssh.Key)
 
 	log.Println("Generate Passwords ...")
 
@@ -166,7 +176,7 @@ func GenerateSecrets(manifest model.Manifest, secrets *v1.Secret, configMap *v1.
 			ssl.RecordCertInfo(configVar)
 
 		case model.GeneratorTypeSSH:
-			ssh.RecordSSHKeyInfo(sshKeys, configVar)
+			ssh.RecordKeyInfo(sshKeys, configVar)
 
 		default:
 			log.Printf("Warning: variable %s has unknown generator type %s\n", configVar.Name, configVar.Generator.Type)
@@ -176,7 +186,7 @@ func GenerateSecrets(manifest model.Manifest, secrets *v1.Secret, configMap *v1.
 	log.Println("Generate SSH ...")
 
 	for _, key := range sshKeys {
-		ssh.GenerateSSHKey(secrets, key)
+		ssh.GenerateKey(secrets, key)
 	}
 
 	log.Println("Generate SSL ...")
@@ -200,10 +210,13 @@ func GenerateSecrets(manifest model.Manifest, secrets *v1.Secret, configMap *v1.
 	log.Println("Done with generation")
 }
 
-func UpdateSecrets(s secretInterface, secrets *v1.Secret, c configMapInterface, configMap *v1.ConfigMap) {
-	var obsoleteSecretName = configMap.Data[PREVIOUS_SECRETS_NAME]
-	configMap.Data[PREVIOUS_SECRETS_NAME] = configMap.Data[CURRENT_SECRETS_NAME]
-	configMap.Data[CURRENT_SECRETS_NAME] = secrets.Name
+// UpdateSecret creates the new Secret object and records the new name in the configmap.
+// The current secrets become the previous secrets, and any previous previous secrets will
+// be deleted. The configmap object in Kube is then updated to match the new configuration.
+func UpdateSecret(s SecretInterface, secrets *v1.Secret, c ConfigMapInterface, configMap *v1.ConfigMap) {
+	var obsoleteSecretName = configMap.Data[previousSecretName]
+	configMap.Data[previousSecretName] = configMap.Data[currentSecretName]
+	configMap.Data[currentSecretName] = secrets.Name
 
 	// create new secret
 	_, err := s.Create(secrets)
@@ -213,14 +226,14 @@ func UpdateSecrets(s secretInterface, secrets *v1.Secret, c configMapInterface, 
 	log.Printf("Created secret `%s`\n", secrets.Name)
 
 	// update configmap
-	if configMap.Data[PREVIOUS_SECRETS_NAME] == "" {
+	if configMap.Data[previousSecretName] == "" {
 		_, err = c.Create(configMap)
 		if err != nil {
 			logFatal(fmt.Sprintf("Error creating configmap %s: %s", configMap.Name, err))
 		}
 		log.Printf("Created configmap `%s`\n", configMap.Name)
 	} else {
-		log.Printf("previous secret `%s`\n", configMap.Data[PREVIOUS_SECRETS_NAME])
+		log.Printf("previous secret `%s`\n", configMap.Data[previousSecretName])
 		_, err = c.Update(configMap)
 		if err != nil {
 			logFatal(fmt.Sprintf("Error updating configmap %s: %s", configMap.Name, err))

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -14,12 +14,14 @@ import (
 	"github.com/SUSE/scf-secret-generator/util"
 )
 
-type SSHKey struct {
+// Key describes a key/fingerprint pair
+type Key struct {
 	PrivateKey  string // Name to associate with private key
 	Fingerprint string // Name to associate with fingerprint
 }
 
-func GenerateSSHKey(secrets *v1.Secret, key SSHKey) {
+// GenerateKey will create a private key and fingerprint
+func GenerateKey(secrets *v1.Secret, key Key) {
 	secretKey := util.ConvertNameToKey(key.PrivateKey)
 	fingerprintKey := util.ConvertNameToKey(key.Fingerprint)
 
@@ -53,7 +55,8 @@ func GenerateSSHKey(secrets *v1.Secret, key SSHKey) {
 	secrets.Data[fingerprintKey] = []byte(ssh.FingerprintLegacyMD5(public))
 }
 
-func RecordSSHKeyInfo(keys map[string]SSHKey, configVar *model.ConfigurationVariable) {
+// RecordKeyInfo records priave key or fingerprint names for later generation
+func RecordKeyInfo(keys map[string]Key, configVar *model.ConfigurationVariable) {
 	// Get or create the key from the map, there should always be
 	// a pair of private keys and fingerprints
 	key := keys[configVar.Generator.ID]

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -19,7 +19,7 @@ type SSHKey struct {
 	Fingerprint string // Name to associate with fingerprint
 }
 
-func GenerateSSHKey(secrets, updates *v1.Secret, key SSHKey) {
+func GenerateSSHKey(secrets *v1.Secret, key SSHKey) {
 	secretKey := util.ConvertNameToKey(key.PrivateKey)
 	fingerprintKey := util.ConvertNameToKey(key.Fingerprint)
 
@@ -29,19 +29,6 @@ func GenerateSSHKey(secrets, updates *v1.Secret, key SSHKey) {
 	}
 
 	log.Printf("- SSH priK: %s\n", key.PrivateKey)
-
-	// Prefer user supplied update data over generating the keys ourselves
-	if len(updates.Data[secretKey]) > 0 {
-		if len(updates.Data[fingerprintKey]) == 0 {
-			log.Fatalf("Update includes %s but not %s", secretKey, fingerprintKey)
-		}
-		secrets.Data[secretKey] = updates.Data[secretKey]
-		secrets.Data[fingerprintKey] = updates.Data[fingerprintKey]
-		return
-	}
-	if len(updates.Data[fingerprintKey]) > 0 {
-		log.Fatalf("Update includes %s but not %s", fingerprintKey, secretKey)
-	}
 
 	// generate private key
 	private, err := rsa.GenerateKey(rand.Reader, 4096)

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -12,19 +12,19 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-// GenerateSSHKey tests
+// GenerateKey tests
 
 func TestNewKeyIsCreated(t *testing.T) {
 	t.Parallel()
 
 	secrets := &v1.Secret{Data: map[string][]byte{}}
 
-	key := SSHKey{
+	key := Key{
 		PrivateKey:  "foo",
 		Fingerprint: "bar",
 	}
 
-	GenerateSSHKey(secrets, key)
+	GenerateKey(secrets, key)
 
 	assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
 	assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
@@ -46,22 +46,22 @@ func TestExistingKeyIsNotChanged(t *testing.T) {
 	secrets.Data["foo"] = fooData
 	secrets.Data["bar"] = barData
 
-	key := SSHKey{
+	key := Key{
 		PrivateKey:  "FOO",
 		Fingerprint: "BAR",
 	}
 
-	GenerateSSHKey(secrets, key)
+	GenerateKey(secrets, key)
 	assert.Equal(t, fooData, secrets.Data["foo"])
 	assert.Equal(t, barData, secrets.Data["bar"])
 }
 
-// RecordSSHKeyInfo tests
+// RecordKeyInfo tests
 
 func TestRecordingFingerprintCreatesKey(t *testing.T) {
 	t.Parallel()
 
-	keys := make(map[string]SSHKey)
+	keys := make(map[string]Key)
 
 	configVar := &model.ConfigurationVariable{
 		Name: "FINGERPRINT_NAME",
@@ -71,7 +71,7 @@ func TestRecordingFingerprintCreatesKey(t *testing.T) {
 		ValueType: model.ValueTypeFingerprint,
 	}
 
-	RecordSSHKeyInfo(keys, configVar)
+	RecordKeyInfo(keys, configVar)
 
 	assert.Equal(t, "FINGERPRINT_NAME", keys["foo"].Fingerprint)
 }
@@ -79,7 +79,7 @@ func TestRecordingFingerprintCreatesKey(t *testing.T) {
 func TestRecordingPrivateCreatesKey(t *testing.T) {
 	t.Parallel()
 
-	keys := make(map[string]SSHKey)
+	keys := make(map[string]Key)
 
 	configVar := &model.ConfigurationVariable{
 		Name: "PRIVATE_KEY_NAME",
@@ -89,7 +89,7 @@ func TestRecordingPrivateCreatesKey(t *testing.T) {
 		ValueType: model.ValueTypePrivateKey,
 	}
 
-	RecordSSHKeyInfo(keys, configVar)
+	RecordKeyInfo(keys, configVar)
 
 	assert.Equal(t, "PRIVATE_KEY_NAME", keys["foo"].PrivateKey)
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -18,14 +18,13 @@ func TestNewKeyIsCreated(t *testing.T) {
 	t.Parallel()
 
 	secrets := &v1.Secret{Data: map[string][]byte{}}
-	updates := &v1.Secret{Data: map[string][]byte{}}
 
 	key := SSHKey{
 		PrivateKey:  "foo",
 		Fingerprint: "bar",
 	}
 
-	GenerateSSHKey(secrets, updates, key)
+	GenerateSSHKey(secrets, key)
 
 	assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
 	assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
@@ -42,7 +41,6 @@ func TestExistingKeyIsNotChanged(t *testing.T) {
 	barData := []byte("bar-data")
 
 	secrets := &v1.Secret{Data: map[string][]byte{}}
-	updates := &v1.Secret{Data: map[string][]byte{}}
 
 	// Also tests for FOO / foo case conversion
 	secrets.Data["foo"] = fooData
@@ -53,7 +51,7 @@ func TestExistingKeyIsNotChanged(t *testing.T) {
 		Fingerprint: "BAR",
 	}
 
-	GenerateSSHKey(secrets, updates, key)
+	GenerateSSHKey(secrets, key)
 	assert.Equal(t, fooData, secrets.Data["foo"])
 	assert.Equal(t, barData, secrets.Data["bar"])
 }

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -25,8 +25,9 @@ var createCA = createCAImpl
 var createCert = createCertImpl
 var getEnv = os.Getenv
 
-const DEFAULT_CA = "cacert"
+const defaultCA = "cacert"
 
+// CertInfo contains all the information required to generate an SSL cert
 type CertInfo struct {
 	PrivateKeyName  string // Name to associate with private key
 	CertificateName string // Name to associate with certificate
@@ -41,6 +42,7 @@ type CertInfo struct {
 
 var certInfo = make(map[string]CertInfo)
 
+// RecordCertInfo record cert information for later generation
 func RecordCertInfo(configVar *model.ConfigurationVariable) {
 	info := certInfo[configVar.Generator.ID]
 
@@ -63,6 +65,7 @@ func RecordCertInfo(configVar *model.ConfigurationVariable) {
 	certInfo[configVar.Generator.ID] = info
 }
 
+// GenerateCerts creates an SSL cert and private key
 func GenerateCerts(secrets *v1.Secret) {
 	// generate all the CAs first because they are needed to sign the certs
 	for id, info := range certInfo {
@@ -137,9 +140,9 @@ func createCertImpl(secrets *v1.Secret, id string) {
 	}
 
 	// XXX Add support for multiple CAs
-	caInfo := certInfo[DEFAULT_CA]
+	caInfo := certInfo[defaultCA]
 	if len(caInfo.PrivateKey) == 0 || len(caInfo.Certificate) == 0 {
-		logFatalf("CA %s not found", DEFAULT_CA)
+		logFatalf("CA %s not found", defaultCA)
 		return
 	}
 

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const CERT_ID = "cert-id"
+const certID = "cert-id"
 
 type MockBase struct {
 	mock.Mock
@@ -50,11 +50,11 @@ func TestRecordCertInfo(t *testing.T) {
 			Secret: true,
 			Generator: &model.ConfigurationVariableGenerator{
 				ValueType: model.ValueTypeCertificate,
-				ID:        CERT_ID,
+				ID:        certID,
 			},
 		}
 		RecordCertInfo(configVar)
-		assert.Equal(t, "cert-name", certInfo[CERT_ID].CertificateName)
+		assert.Equal(t, "cert-name", certInfo[certID].CertificateName)
 	})
 
 	t.Run("Private key should be added to certInfo", func(t *testing.T) {
@@ -65,11 +65,11 @@ func TestRecordCertInfo(t *testing.T) {
 			Secret: true,
 			Generator: &model.ConfigurationVariableGenerator{
 				ValueType: model.ValueTypePrivateKey,
-				ID:        CERT_ID,
+				ID:        certID,
 			},
 		}
 		RecordCertInfo(configVar)
-		assert.Equal(t, "private-key-name", certInfo[CERT_ID].PrivateKeyName)
+		assert.Equal(t, "private-key-name", certInfo[certID].PrivateKeyName)
 	})
 
 	t.Run("Private key and cert should be in the same mapped value", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestRecordCertInfo(t *testing.T) {
 			Secret: true,
 			Generator: &model.ConfigurationVariableGenerator{
 				ValueType: model.ValueTypeCertificate,
-				ID:        CERT_ID,
+				ID:        certID,
 			},
 		}
 		RecordCertInfo(configVar)
@@ -89,12 +89,12 @@ func TestRecordCertInfo(t *testing.T) {
 			Secret: true,
 			Generator: &model.ConfigurationVariableGenerator{
 				ValueType: model.ValueTypePrivateKey,
-				ID:        CERT_ID,
+				ID:        certID,
 			},
 		}
 		RecordCertInfo(configVar)
-		assert.Equal(t, "cert-name", certInfo[CERT_ID].CertificateName)
-		assert.Equal(t, "private-key-name", certInfo[CERT_ID].PrivateKeyName)
+		assert.Equal(t, "cert-name", certInfo[certID].CertificateName)
+		assert.Equal(t, "private-key-name", certInfo[certID].PrivateKeyName)
 	})
 
 	t.Run("SubjectNames are added to certInfo", func(t *testing.T) {
@@ -106,11 +106,11 @@ func TestRecordCertInfo(t *testing.T) {
 			Generator: &model.ConfigurationVariableGenerator{
 				ValueType:    model.ValueTypePrivateKey,
 				SubjectNames: []string{"subject names"},
-				ID:           CERT_ID,
+				ID:           certID,
 			},
 		}
 		RecordCertInfo(configVar)
-		assert.Equal(t, "subject names", certInfo[CERT_ID].SubjectNames[0])
+		assert.Equal(t, "subject names", certInfo[certID].SubjectNames[0])
 	})
 
 	t.Run("Rolename is added to certInfo", func(t *testing.T) {
@@ -122,11 +122,11 @@ func TestRecordCertInfo(t *testing.T) {
 			Generator: &model.ConfigurationVariableGenerator{
 				ValueType: model.ValueTypePrivateKey,
 				RoleName:  "role name",
-				ID:        CERT_ID,
+				ID:        certID,
 			},
 		}
 		RecordCertInfo(configVar)
-		assert.Equal(t, "role name", certInfo[CERT_ID].RoleName)
+		assert.Equal(t, "role name", certInfo[certID].RoleName)
 	})
 }
 
@@ -147,20 +147,20 @@ func TestGenerateCerts(t *testing.T) {
 		// Call createCA for CA certificates
 		//
 		certInfo = make(map[string]CertInfo)
-		certInfo[CERT_ID] = CertInfo{IsAuthority: true}
+		certInfo[certID] = CertInfo{IsAuthority: true}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCA returns true
-		mockSSL.On("createCA", secrets, CERT_ID)
+		mockSSL.On("createCA", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCA", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCA", secrets, certID)
 
 		// When createCA returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCA", secrets, CERT_ID)
+		mockSSL.On("createCA", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCA", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCA", secrets, certID)
 	})
 
 	t.Run("Check createCert is called properly when SubjectNames specified", func(t *testing.T) {
@@ -171,22 +171,22 @@ func TestGenerateCerts(t *testing.T) {
 		// If subjectnames > 0 and rolename is blank, call createCert
 		//
 		certInfo = make(map[string]CertInfo)
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			SubjectNames: []string{"subject"},
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 
 	})
 
@@ -198,22 +198,22 @@ func TestGenerateCerts(t *testing.T) {
 		// If no subjectnames and the rolename is not blank, call createCert
 		//
 		certInfo = make(map[string]CertInfo)
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			RoleName: "rolename",
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 
 	})
 
@@ -225,23 +225,23 @@ func TestGenerateCerts(t *testing.T) {
 		// If subjectnames > 0 and rolename is not blank, call createCert
 		//
 		certInfo = make(map[string]CertInfo)
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			RoleName:     "rolename",
 			SubjectNames: []string{"subject"},
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 	})
 
 	t.Run("Check createCert is called properly when neither SubjectNames nor RoleNames specified", func(t *testing.T) {
@@ -252,23 +252,23 @@ func TestGenerateCerts(t *testing.T) {
 		// If subjectnames == 0 and rolename is blank, call createCert
 		//
 		certInfo = make(map[string]CertInfo)
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			RoleName:     "",
 			SubjectNames: []string{},
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, CERT_ID)
+		mockSSL.On("createCert", secrets, certID)
 		GenerateCerts(secrets)
-		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
+		mockSSL.AssertCalled(t, "createCert", secrets, certID)
 	})
 }
 
@@ -287,7 +287,7 @@ func TestCreateCA(t *testing.T) {
 		certInfo = make(map[string]CertInfo)
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
@@ -295,22 +295,22 @@ func TestCreateCA(t *testing.T) {
 		secrets.Data["private-key"] = []byte("private-key-data")
 		secrets.Data["certificate-name"] = []byte("certificate-data")
 
-		createCAImpl(secrets, CERT_ID)
+		createCAImpl(secrets, certID)
 
-		assert.Equal(t, []byte("private-key-data"), certInfo[CERT_ID].PrivateKey)
-		assert.Equal(t, []byte("certificate-data"), certInfo[CERT_ID].Certificate)
+		assert.Equal(t, []byte("private-key-data"), certInfo[certID].PrivateKey)
+		assert.Equal(t, []byte("certificate-data"), certInfo[certID].Certificate)
 	})
 
 	t.Run("createCA should generate valid data", func(t *testing.T) {
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
 
-		createCAImpl(secrets, CERT_ID)
-		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName], []byte{})
-		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].CertificateName], []byte{})
+		createCAImpl(secrets, certID)
+		assert.NotEqual(t, secrets.Data[certInfo[certID].PrivateKeyName], []byte{})
+		assert.NotEqual(t, secrets.Data[certInfo[certID].CertificateName], []byte{})
 	})
 }
 
@@ -338,8 +338,8 @@ func TestCreateCert(t *testing.T) {
 	secrets := &v1.Secret{Data: map[string][]byte{}}
 
 	certInfo = make(map[string]CertInfo)
-	createCAImpl(secrets, DEFAULT_CA)
-	defaultCA := certInfo[DEFAULT_CA]
+	createCAImpl(secrets, defaultCA)
+	defaultCAInfo := certInfo[defaultCA]
 
 	t.Run("If secrets has a private key, return false", func(t *testing.T) {
 		var mockLog MockLog
@@ -348,11 +348,11 @@ func TestCreateCert(t *testing.T) {
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 		secrets.Data["private-key"] = []byte("private-key-data")
 		secrets.Data["certificate-name"] = []byte("certificate-data")
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
-		createCertImpl(secrets, CERT_ID)
+		createCertImpl(secrets, certID)
 	})
 
 	t.Run("If updateCert() is true, return true", func(t *testing.T) {
@@ -361,11 +361,11 @@ func TestCreateCert(t *testing.T) {
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
-		createCertImpl(secrets, CERT_ID)
+		createCertImpl(secrets, certID)
 	})
 
 	t.Run("If the default CA private key isn't found, logFatalf", func(t *testing.T) {
@@ -373,16 +373,16 @@ func TestCreateCert(t *testing.T) {
 		logFatalf = mockLog.Fatalf
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		certInfo[DEFAULT_CA] = CertInfo{
+		certInfo[defaultCA] = CertInfo{
 			Certificate: []byte("default-certificate"),
 		}
 		mockLog.On("Fatalf",
 			"CA %s not found",
-			[]interface{}{DEFAULT_CA})
-		createCertImpl(secrets, CERT_ID)
+			[]interface{}{defaultCA})
+		createCertImpl(secrets, certID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"CA %s not found",
-			[]interface{}{DEFAULT_CA})
+			[]interface{}{defaultCA})
 
 	})
 
@@ -391,16 +391,16 @@ func TestCreateCert(t *testing.T) {
 		logFatalf = mockLog.Fatalf
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		certInfo[DEFAULT_CA] = CertInfo{
+		certInfo[defaultCA] = CertInfo{
 			PrivateKey: []byte("private-key"),
 		}
 		mockLog.On("Fatalf",
 			"CA %s not found",
-			[]interface{}{DEFAULT_CA})
-		createCertImpl(secrets, CERT_ID)
+			[]interface{}{defaultCA})
+		createCertImpl(secrets, certID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"CA %s not found",
-			[]interface{}{DEFAULT_CA})
+			[]interface{}{defaultCA})
 
 	})
 
@@ -411,11 +411,11 @@ func TestCreateCert(t *testing.T) {
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// Create a bogus default CA
-		certInfo[DEFAULT_CA] = CertInfo{
+		certInfo[defaultCA] = CertInfo{
 			Certificate: []byte("default-certificate"),
 			PrivateKey:  []byte("private-key"),
 		}
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
@@ -423,7 +423,7 @@ func TestCreateCert(t *testing.T) {
 		mockLog.On("Fatalf",
 			"Cannot parse CA cert: %s",
 			[]interface{}{cferr.New(1000, 2)})
-		createCertImpl(secrets, CERT_ID)
+		createCertImpl(secrets, certID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"Cannot parse CA cert: %s",
 			[]interface{}{cferr.New(1000, 2)})
@@ -437,10 +437,10 @@ func TestCreateCert(t *testing.T) {
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
 		// Invalidate the private key of the default CA
-		info := defaultCA
+		info := defaultCAInfo
 		info.PrivateKey = []byte("private-key")
-		certInfo[DEFAULT_CA] = info
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[defaultCA] = info
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
@@ -448,7 +448,7 @@ func TestCreateCert(t *testing.T) {
 		mockLog.On("Fatalf",
 			"Cannot parse CA private key: %s",
 			[]interface{}{cferr.New(2000, 2)})
-		createCertImpl(secrets, CERT_ID)
+		createCertImpl(secrets, certID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"Cannot parse CA private key: %s",
 			[]interface{}{cferr.New(2000, 2)})
@@ -460,17 +460,17 @@ func TestCreateCert(t *testing.T) {
 		logFatalf = mockLog.Fatalf
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		certInfo[DEFAULT_CA] = defaultCA
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[defaultCA] = defaultCAInfo
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
 		}
-		createCertImpl(secrets, CERT_ID)
-		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName], []byte{})
-		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].CertificateName], []byte{})
-		_, err := tls.X509KeyPair(secrets.Data[certInfo[CERT_ID].CertificateName],
-			secrets.Data[certInfo[CERT_ID].PrivateKeyName])
+		createCertImpl(secrets, certID)
+		assert.NotEqual(t, secrets.Data[certInfo[certID].PrivateKeyName], []byte{})
+		assert.NotEqual(t, secrets.Data[certInfo[certID].CertificateName], []byte{})
+		_, err := tls.X509KeyPair(secrets.Data[certInfo[certID].CertificateName],
+			secrets.Data[certInfo[certID].PrivateKeyName])
 		assert.NoError(t, err)
 
 	})
@@ -492,18 +492,18 @@ func TestCreateCert(t *testing.T) {
 		util.OverrideEnv("KUBERNETES_NAMESPACE", "namespace")
 		util.OverrideEnv("KUBE_SERVICE_DOMAIN_SUFFIX", "invalid")
 
-		certInfo[DEFAULT_CA] = defaultCA
-		certInfo[CERT_ID] = CertInfo{
+		certInfo[defaultCA] = defaultCAInfo
+		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{},
 			RoleName:        "dummy-role",
 		}
-		createCertImpl(secrets, CERT_ID)
-		assert.NotEmpty(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName])
-		assert.NotEmpty(t, secrets.Data[certInfo[CERT_ID].CertificateName])
+		createCertImpl(secrets, certID)
+		assert.NotEmpty(t, secrets.Data[certInfo[certID].PrivateKeyName])
+		assert.NotEmpty(t, secrets.Data[certInfo[certID].CertificateName])
 
-		certBlob, _ := pem.Decode(secrets.Data[certInfo[CERT_ID].CertificateName])
+		certBlob, _ := pem.Decode(secrets.Data[certInfo[certID].CertificateName])
 		if !assert.NotNil(t, certBlob, "Failed to decode certificate PEM block") {
 			return
 		}

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -33,17 +33,12 @@ type MockSSL struct {
 	MockBase
 }
 
-func (m *MockSSL) createCA(secrets, updates *v1.Secret, id string) {
-	m.Called(secrets, updates, id)
+func (m *MockSSL) createCA(secrets *v1.Secret, id string) {
+	m.Called(secrets, id)
 }
 
-func (m *MockSSL) createCert(secrets, updates *v1.Secret, id string) {
-	m.Called(secrets, updates, id)
-}
-
-func (m *MockSSL) updateCert(secrets, updates *v1.Secret, id string) bool {
-	results := m.Called(secrets, updates, id)
-	return results.Bool(0)
+func (m *MockSSL) createCert(secrets *v1.Secret, id string) {
+	m.Called(secrets, id)
 }
 
 func TestRecordCertInfo(t *testing.T) {
@@ -154,19 +149,18 @@ func TestGenerateCerts(t *testing.T) {
 		certInfo = make(map[string]CertInfo)
 		certInfo[CERT_ID] = CertInfo{IsAuthority: true}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCA returns true
-		mockSSL.On("createCA", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCA", secrets, updates, CERT_ID)
+		mockSSL.On("createCA", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCA", secrets, CERT_ID)
 
 		// When createCA returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCA", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCA", secrets, updates, CERT_ID)
+		mockSSL.On("createCA", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCA", secrets, CERT_ID)
 	})
 
 	t.Run("Check createCert is called properly when SubjectNames specified", func(t *testing.T) {
@@ -181,19 +175,18 @@ func TestGenerateCerts(t *testing.T) {
 			SubjectNames: []string{"subject"},
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 
 	})
 
@@ -209,19 +202,18 @@ func TestGenerateCerts(t *testing.T) {
 			RoleName: "rolename",
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 
 	})
 
@@ -238,19 +230,18 @@ func TestGenerateCerts(t *testing.T) {
 			SubjectNames: []string{"subject"},
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 	})
 
 	t.Run("Check createCert is called properly when neither SubjectNames nor RoleNames specified", func(t *testing.T) {
@@ -266,19 +257,18 @@ func TestGenerateCerts(t *testing.T) {
 			SubjectNames: []string{},
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// When createCert returns true
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 
 		// When createCert returns false
 		mockSSL.ExpectedCalls = nil
 		mockSSL.Calls = nil
-		mockSSL.On("createCert", secrets, updates, CERT_ID)
-		GenerateCerts(secrets, updates)
-		mockSSL.AssertCalled(t, "createCert", secrets, updates, CERT_ID)
+		mockSSL.On("createCert", secrets, CERT_ID)
+		GenerateCerts(secrets)
+		mockSSL.AssertCalled(t, "createCert", secrets, CERT_ID)
 	})
 }
 
@@ -290,22 +280,12 @@ func TestRsaKeyRequest(t *testing.T) {
 }
 
 func TestCreateCA(t *testing.T) {
-	origUpdateCert := updateCert
-
-	defer func() {
-		updateCert = origUpdateCert
-	}()
-
 	t.Run("createCA shouldn't update if PrivateKeyName is defined", func(t *testing.T) {
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		//
 		// If PrivateKeyName isn't blank, return false
 		//
 		certInfo = make(map[string]CertInfo)
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		certInfo[CERT_ID] = CertInfo{
 			PrivateKeyName:  "private-key",
@@ -315,40 +295,20 @@ func TestCreateCA(t *testing.T) {
 		secrets.Data["private-key"] = []byte("private-key-data")
 		secrets.Data["certificate-name"] = []byte("certificate-data")
 
-		createCAImpl(secrets, updates, CERT_ID)
+		createCAImpl(secrets, CERT_ID)
 
 		assert.Equal(t, []byte("private-key-data"), certInfo[CERT_ID].PrivateKey)
 		assert.Equal(t, []byte("certificate-data"), certInfo[CERT_ID].Certificate)
 	})
 
-	t.Run("createCA should trigger an update if updateCert returns true", func(t *testing.T) {
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
-		//
-		// If updateCert() is true, return true
-		//
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		certInfo = make(map[string]CertInfo)
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(true)
-		createCAImpl(secrets, updates, CERT_ID)
-		mockSSL.AssertCalled(t, "updateCert", secrets, updates, CERT_ID)
-	})
-
 	t.Run("createCA should generate valid data", func(t *testing.T) {
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 		certInfo[CERT_ID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
 
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
-		createCAImpl(secrets, updates, CERT_ID)
+		createCAImpl(secrets, CERT_ID)
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName], []byte{})
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].CertificateName], []byte{})
 	})
@@ -376,73 +336,50 @@ func TestAddHost(t *testing.T) {
 func TestCreateCert(t *testing.T) {
 	// Initialize a default CA for later use in this test
 	secrets := &v1.Secret{Data: map[string][]byte{}}
-	updates := &v1.Secret{Data: map[string][]byte{}}
 
 	certInfo = make(map[string]CertInfo)
-	createCAImpl(secrets, updates, DEFAULT_CA)
+	createCAImpl(secrets, DEFAULT_CA)
 	defaultCA := certInfo[DEFAULT_CA]
-
-	origLogFatalf := logFatalf
-	origUpdateCert := updateCert
-	defer func() {
-		logFatalf = origLogFatalf
-		updateCert = origUpdateCert
-	}()
 
 	t.Run("If secrets has a private key, return false", func(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 		secrets.Data["private-key"] = []byte("private-key-data")
 		secrets.Data["certificate-name"] = []byte("certificate-data")
 		certInfo[CERT_ID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 	})
 
 	t.Run("If updateCert() is true, return true", func(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		certInfo[CERT_ID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 		}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(true)
-		createCertImpl(secrets, updates, CERT_ID)
-		mockSSL.AssertCalled(t, "updateCert", secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 	})
 
 	t.Run("If the default CA private key isn't found, logFatalf", func(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		certInfo[DEFAULT_CA] = CertInfo{
 			Certificate: []byte("default-certificate"),
 		}
 		mockLog.On("Fatalf",
 			"CA %s not found",
 			[]interface{}{DEFAULT_CA})
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"CA %s not found",
 			[]interface{}{DEFAULT_CA})
@@ -453,19 +390,14 @@ func TestCreateCert(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		certInfo[DEFAULT_CA] = CertInfo{
 			PrivateKey: []byte("private-key"),
 		}
 		mockLog.On("Fatalf",
 			"CA %s not found",
 			[]interface{}{DEFAULT_CA})
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"CA %s not found",
 			[]interface{}{DEFAULT_CA})
@@ -476,11 +408,7 @@ func TestCreateCert(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// Create a bogus default CA
 		certInfo[DEFAULT_CA] = CertInfo{
@@ -492,11 +420,10 @@ func TestCreateCert(t *testing.T) {
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
 		}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		mockLog.On("Fatalf",
 			"Cannot parse CA cert: %s",
 			[]interface{}{cferr.New(1000, 2)})
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"Cannot parse CA cert: %s",
 			[]interface{}{cferr.New(1000, 2)})
@@ -507,11 +434,7 @@ func TestCreateCert(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		// Invalidate the private key of the default CA
 		info := defaultCA
@@ -522,11 +445,10 @@ func TestCreateCert(t *testing.T) {
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
 		}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
 		mockLog.On("Fatalf",
 			"Cannot parse CA private key: %s",
 			[]interface{}{cferr.New(2000, 2)})
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 		mockLog.AssertCalled(t, "Fatalf",
 			"Cannot parse CA private key: %s",
 			[]interface{}{cferr.New(2000, 2)})
@@ -537,19 +459,14 @@ func TestCreateCert(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 		certInfo[DEFAULT_CA] = defaultCA
 		certInfo[CERT_ID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
 		}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName], []byte{})
 		assert.NotEqual(t, secrets.Data[certInfo[CERT_ID].CertificateName], []byte{})
 		_, err := tls.X509KeyPair(secrets.Data[certInfo[CERT_ID].CertificateName],
@@ -562,9 +479,6 @@ func TestCreateCert(t *testing.T) {
 		var mockLog MockLog
 		logFatalf = mockLog.Fatalf
 
-		var mockSSL MockSSL
-		updateCert = mockSSL.updateCert
-
 		origGetEnv := getEnv
 		defer func() {
 			getEnv = origGetEnv
@@ -573,7 +487,6 @@ func TestCreateCert(t *testing.T) {
 			return "2"
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
 
 		defer util.ClearOverrides()
 		util.OverrideEnv("KUBERNETES_NAMESPACE", "namespace")
@@ -586,8 +499,7 @@ func TestCreateCert(t *testing.T) {
 			SubjectNames:    []string{},
 			RoleName:        "dummy-role",
 		}
-		mockSSL.On("updateCert", secrets, updates, CERT_ID).Return(false)
-		createCertImpl(secrets, updates, CERT_ID)
+		createCertImpl(secrets, CERT_ID)
 		assert.NotEmpty(t, secrets.Data[certInfo[CERT_ID].PrivateKeyName])
 		assert.NotEmpty(t, secrets.Data[certInfo[CERT_ID].CertificateName])
 
@@ -603,79 +515,5 @@ func TestCreateCert(t *testing.T) {
 			assert.NotContains(t, cert.DNSNames, "dummy-role-set")
 			assert.NotContains(t, cert.DNSNames, "*.*.dummy-role-set")
 		}
-	})
-}
-
-func TestUpdateCert(t *testing.T) {
-	origLogFatalf := logFatalf
-	defer func() {
-		logFatalf = origLogFatalf
-	}()
-
-	t.Run("When updates.Data has a PrivateKeyName and a cert name, keep it", func(t *testing.T) {
-		var mockLog MockLog
-		logFatalf = mockLog.Fatalf
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		certInfo = make(map[string]CertInfo)
-		certInfo[CERT_ID] = CertInfo{
-			PrivateKeyName:  "private-key",
-			CertificateName: "certificate-name",
-		}
-
-		updates.Data["private-key"] = []byte("private-key-data")
-		updates.Data["certificate-name"] = []byte("certificate-data")
-
-		result := updateCertImpl(secrets, updates, CERT_ID)
-
-		assert.True(t, result)
-		assert.Equal(t, []byte("private-key-data"), certInfo[CERT_ID].PrivateKey)
-		assert.Equal(t, []byte("certificate-data"), certInfo[CERT_ID].Certificate)
-	})
-
-	t.Run("If updates.Data has a PrivateKeyName but doesn't have a cert name, logFatal", func(t *testing.T) {
-		var mockLog MockLog
-		logFatalf = mockLog.Fatalf
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		updates.Data["private-key"] = []byte("private-key-data")
-		mockLog.On("Fatalf",
-			"Update includes %s but not %s",
-			[]interface{}{"private-key", "certificate-name"})
-		_ = updateCertImpl(secrets, updates, CERT_ID)
-		mockLog.AssertCalled(t, "Fatalf",
-			"Update includes %s but not %s",
-			[]interface{}{"private-key", "certificate-name"})
-
-	})
-
-	t.Run("If updates.Data doesn't have a PrivateKeyName but it has a cert name, logFatal", func(t *testing.T) {
-		var mockLog MockLog
-		logFatalf = mockLog.Fatalf
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		updates.Data["certificate-name"] = []byte("certificate-data")
-		mockLog.On("Fatalf",
-			"Update includes %s but not %s",
-			[]interface{}{"certificate-name", "private-key"})
-		_ = updateCertImpl(secrets, updates, CERT_ID)
-		mockLog.AssertCalled(t, "Fatalf",
-			"Update includes %s but not %s",
-			[]interface{}{"certificate-name", "private-key"})
-
-	})
-
-	t.Run("When updates.Data doesn't have a PrivateKeyName or a cert name, return false", func(t *testing.T) {
-		var mockLog MockLog
-		logFatalf = mockLog.Fatalf
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-		updates := &v1.Secret{Data: map[string][]byte{}}
-		certInfo[CERT_ID] = CertInfo{}
-		result := updateCertImpl(secrets, updates, CERT_ID)
-		assert.False(t, result)
 	})
 }

--- a/util/util.go
+++ b/util/util.go
@@ -37,10 +37,12 @@ func ClearOverrides() {
 	override = make(map[string]string)
 }
 
+// ConvertNameToKey turns a name to lowercase and replaces underscores by dashes
 func ConvertNameToKey(name string) string {
 	return strings.Replace(strings.ToLower(name), "_", "-", -1)
 }
 
+// ExpandEnvTemplates expands a Go template string using an (overridable) env map
 func ExpandEnvTemplates(str string) string {
 	t, err := template.New("").Parse(str)
 	if err != nil {


### PR DESCRIPTION
* `secrets` contain only generated secrets, not user supplied ones

* `secret-update-#` is no longer needed

* `secrets-config` configmap keeps record of current and previous secret names as well as current secrets generation

* `KUBE_SECRETS_GENERATION_NAME` specifies the name of the new secrets

* `KUBE_SECRETS_GENERATION_COUNTER` determines if all immutable secrets shoud be regenerated

* Any previous-previous secrets will be deleted once the new secrets have been created.

[trello#0s4zlOZg]