### PR TITLE
Restore template expansion in cert subject names

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,12 +19,16 @@ func main() {
 	}
 
 	sg := secrets.SecretGenerator{
+		Domain:              os.Getenv("DOMAIN"),
 		Namespace:           os.Getenv("KUBERNETES_NAMESPACE"),
 		ServiceDomainSuffix: os.Getenv("KUBE_SERVICE_DOMAIN_SUFFIX"),
 		SecretsName:         os.Getenv("KUBE_SECRETS_GENERATION_NAME"),
 		SecretsGeneration:   os.Getenv("KUBE_SECRETS_GENERATION_COUNTER"),
 	}
 	// XXX All these settings should be passed from the commandline and not the environment
+	if sg.Domain == "" {
+		log.Fatal("DOMAIN is not set")
+	}
 	if sg.Namespace == "" {
 		log.Fatal("KUBERNETES_NAMESPACE is not set")
 	}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -30,6 +30,7 @@ const configVersion = "config-version"
 
 // SecretGenerator contains all global state for creating new secrets
 type SecretGenerator struct {
+	Domain              string
 	Namespace           string
 	ServiceDomainSuffix string
 	SecretsName         string
@@ -96,7 +97,7 @@ func kubeClientset() (*kubernetes.Clientset, error) {
 	return clientset, err
 }
 
-// GetConfigMapInterface returns a configmap interface for the KUBERNETES_NAMESPACE
+// GetConfigMapInterface returns a configmap interface for the namespace
 func (sg *SecretGenerator) getConfigMapInterface() (configMapInterface, error) {
 	clientset, err := kubeClientset()
 	if err != nil {
@@ -105,7 +106,7 @@ func (sg *SecretGenerator) getConfigMapInterface() (configMapInterface, error) {
 	return clientset.CoreV1().ConfigMaps(sg.Namespace), nil
 }
 
-// GetSecretInterface returns a secrets interface for the KUBERNETES_NAMESPACE
+// GetSecretInterface returns a secrets interface for the namespace
 func (sg *SecretGenerator) getSecretInterface() (secretInterface, error) {
 	clientset, err := kubeClientset()
 	if err != nil {
@@ -212,7 +213,7 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 
 	log.Println("Generate SSL ...")
 
-	ssl.GenerateCerts(certInfo, sg.Namespace, sg.ServiceDomainSuffix, secrets)
+	ssl.GenerateCerts(certInfo, sg.Namespace, sg.Domain, sg.ServiceDomainSuffix, secrets)
 
 	// remove all secrets no longer referenced in the manifest
 	generatedSecret := make(map[string]bool)


### PR DESCRIPTION
It is still used via the role manifest. Only allow a predefined list of variables though, and not anything from the environment.

[trello#0s4zlOZg]