### PR TITLE
Add json tags to Generator fields

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -31,12 +31,15 @@ const (
 
 // ConfigurationVariableGenerator describes how to automatically generate values
 // for a configuration variable
+// WARNING: Avoid re-ordering the fields; that would trigger secrets re-generation because
+// it changes the serialized generator input strings. For the same reason additional fields
+// should be added with the omitempty attribute.
 type ConfigurationVariableGenerator struct {
-	ID           string        `yaml:"id,omitempty"`
-	Type         GeneratorType `yaml:"type"`
-	ValueType    ValueType     `yaml:"value_type,omitempty"`
-	SubjectNames []string      `yaml:"subject_names,omitempty"`
-	RoleName     string        `yaml:"role_name,omitempty"`
+	ID           string        `json:"id,omitempty" yaml:"id,omitempty"`
+	Type         GeneratorType `json:"type" yaml:"type"`
+	ValueType    ValueType     `json:"value_type,omitempty" yaml:"value_type,omitempty"`
+	SubjectNames []string      `json:"subject_names,omitempty" yaml:"subject_names,omitempty"`
+	RoleName     string        `json:"role_name,omitempty" yaml:"role_name,omitempty"`
 }
 
 // ConfigurationVariable is a configuration to be exposed to the IaaS

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -719,6 +719,8 @@ func TestGenerateSecret(t *testing.T) {
 
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
 		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorInputSuffix])
+		assert.NotContains(t, string(secrets.Data["ssl-cert"+generatorInputSuffix]), "subject_names")
+
 		assert.NotEmpty(t, secrets.Data["ssl-key"])
 		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorInputSuffix])
 
@@ -726,8 +728,11 @@ func TestGenerateSecret(t *testing.T) {
 
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
 		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorInputSuffix])
+		assert.Contains(t, string(secrets.Data["ssl-cert"+generatorInputSuffix]), "subject_names")
+
 		assert.NotEmpty(t, secrets.Data["ssl-key"])
 		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorInputSuffix])
+
 		assert.NotEqual(t, []byte("cert"), secrets.Data["ssl-cert"])
 		assert.NotEqual(t, []byte("key"), secrets.Data["ssl-key"])
 	})


### PR DESCRIPTION
That way empty fields will be omitted from the generator input strings,
preventing unneccessary secrets rotations if we ever add additional fields.

[trello#tIMZZdx1]