### PR TITLE
Make secrets generator more robust

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,34 +9,22 @@ import (
 	"github.com/SUSE/scf-secret-generator/secrets"
 )
 
-var domain = flag.String(
-	"domain",
-	"",
-	"Domain",
-)
-
-var namespace = flag.String(
-	"namespace",
-	"",
-	"Kubernetes namespace",
-)
-
-var secretsName = flag.String(
-	"secretsName",
-	"",
-	"Secrets Name (version string of the helm chart)",
-)
-
-var secretsGeneration = flag.String(
-	"secretsGeneration",
-	"",
-	"Secrets Generation (rotation counter)",
-)
-
 var certExpiration = flag.Int(
 	"certExpiration",
 	30*365+7, // just over 30 years
 	"Certificate expiration (in days)",
+)
+
+var clusterDomain = flag.String(
+	"clusterDomain",
+	"cluster.local",
+	"Kubernetes cluster domain, normally cluster.local",
+)
+
+var domain = flag.String(
+	"domain",
+	"",
+	"Domain",
 )
 
 var installMode = flag.String(
@@ -45,16 +33,28 @@ var installMode = flag.String(
 	"Installation mode: either `install` or `upgrade`",
 )
 
+var namespace = flag.String(
+	"namespace",
+	"",
+	"Kubernetes namespace",
+)
+
 var roleManifest = flag.String(
 	"roleManifest",
 	"",
 	"Role manifest containing definitions for all secrets to be generated",
 )
 
-var clusterDomain = flag.String(
-	"clusterDomain",
-	"cluster.local",
-	"Kubernetes cluster domain, normally cluster.local",
+var secretsGeneration = flag.String(
+	"secretsGeneration",
+	"",
+	"Secrets Generation (rotation counter)",
+)
+
+var secretsName = flag.String(
+	"secretsName",
+	"",
+	"Secrets Name (version string of the helm chart)",
 )
 
 func main() {
@@ -67,13 +67,13 @@ func main() {
 	}
 
 	sg := secrets.SecretGenerator{
-		Domain:            *domain,
-		Namespace:         *namespace,
-		SecretsName:       *secretsName,
-		SecretsGeneration: *secretsGeneration,
 		CertExpiration:    *certExpiration,
-		IsInstall:         (*installMode == "install"),
 		ClusterDomain:     *clusterDomain,
+		Domain:            *domain,
+		IsInstall:         (*installMode == "install"),
+		Namespace:         *namespace,
+		SecretsGeneration: *secretsGeneration,
+		SecretsName:       *secretsName,
 	}
 	if sg.Domain == "" {
 		log.Fatal("-domain is not set")
@@ -81,11 +81,11 @@ func main() {
 	if sg.Namespace == "" {
 		log.Fatal("-namespace is not set")
 	}
-	if sg.SecretsName == "" {
-		log.Fatal("-secretsName is not set")
-	}
 	if sg.SecretsGeneration == "" {
 		log.Fatal("-secretsGeneration is not set")
+	}
+	if sg.SecretsName == "" {
+		log.Fatal("-secretsName is not set")
 	}
 
 	file, err := os.Open(flag.Arg(0))

--- a/main.go
+++ b/main.go
@@ -45,18 +45,24 @@ var certExpiration = flag.Int(
 	"Certificate expiration (in days)",
 )
 
-var isInstall = flag.Bool(
-	"isInstall",
-	false,
-	"Generating initial secrets; not an upgrade",
+var installMode = flag.String(
+	"mode",
+	"",
+	"Installation mode: either `install` or `upgrade`",
+)
+
+var roleManifest = flag.String(
+	"roleManifest",
+	"",
+	"Role manifest containing definitions for all secrets to be generated",
 )
 
 func main() {
 	flag.Parse()
 
-	if flag.NArg() != 1 {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [OPTIONS] ROLE-MANIFEST\n", os.Args[0])
-		flag.PrintDefaults()
+	if *installMode != "install" && *installMode != "upgrade" {
+		fmt.Fprintf(flag.CommandLine.Output(), "Invalid -mode: `%s`, must be either `install` or `upgrade`.\n", *installMode)
+		flag.Usage()
 		os.Exit(1)
 	}
 
@@ -67,7 +73,7 @@ func main() {
 		SecretsName:         *secretsName,
 		SecretsGeneration:   *secretsGeneration,
 		CertExpiration:      *certExpiration,
-		IsInstall:           *isInstall,
+		IsInstall:           (*installMode == "install"),
 	}
 	if sg.Domain == "" {
 		log.Fatal("-domain is not set")

--- a/main.go
+++ b/main.go
@@ -21,12 +21,6 @@ var namespace = flag.String(
 	"Kubernetes namespace",
 )
 
-var serviceDomainSuffix = flag.String(
-	"serviceDomainSuffix",
-	"",
-	"Service Domain Suffix",
-)
-
 var secretsName = flag.String(
 	"secretsName",
 	"",
@@ -57,6 +51,12 @@ var roleManifest = flag.String(
 	"Role manifest containing definitions for all secrets to be generated",
 )
 
+var clusterDomain = flag.String(
+	"clusterDomain",
+	"cluster.local",
+	"Kubernetes cluster domain, normally cluster.local",
+)
+
 func main() {
 	flag.Parse()
 
@@ -67,22 +67,19 @@ func main() {
 	}
 
 	sg := secrets.SecretGenerator{
-		Domain:              *domain,
-		Namespace:           *namespace,
-		ServiceDomainSuffix: *serviceDomainSuffix,
-		SecretsName:         *secretsName,
-		SecretsGeneration:   *secretsGeneration,
-		CertExpiration:      *certExpiration,
-		IsInstall:           (*installMode == "install"),
+		Domain:            *domain,
+		Namespace:         *namespace,
+		SecretsName:       *secretsName,
+		SecretsGeneration: *secretsGeneration,
+		CertExpiration:    *certExpiration,
+		IsInstall:         (*installMode == "install"),
+		ClusterDomain:     *clusterDomain,
 	}
 	if sg.Domain == "" {
 		log.Fatal("-domain is not set")
 	}
 	if sg.Namespace == "" {
 		log.Fatal("-namespace is not set")
-	}
-	if sg.ServiceDomainSuffix == "" {
-		log.Fatal("-serviceDomainSuffix is not set")
 	}
 	if sg.SecretsName == "" {
 		log.Fatal("-secretsName is not set")

--- a/main.go
+++ b/main.go
@@ -45,6 +45,12 @@ var certExpiration = flag.Int(
 	"Certificate expiration (in days)",
 )
 
+var isInstall = flag.Bool(
+	"isInstall",
+	false,
+	"Generating initial secrets; not an upgrade",
+)
+
 func main() {
 	flag.Parse()
 
@@ -61,6 +67,7 @@ func main() {
 		SecretsName:         *secretsName,
 		SecretsGeneration:   *secretsGeneration,
 		CertExpiration:      *certExpiration,
+		IsInstall:           *isInstall,
 	}
 	if sg.Domain == "" {
 		log.Fatal("-domain is not set")

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -411,7 +411,7 @@ func (sg *SecretGenerator) updateSecret(s secretInterface, secrets *v1.Secret, c
 
 	if obsoleteSecretName != "" {
 		err = s.Delete(obsoleteSecretName, &metav1.DeleteOptions{})
-		if err != nil {
+		if err != nil && obsoleteSecretName != legacySecretName {
 			log.Printf(fmt.Sprintf("Error deleting secrets `%s`: %s", obsoleteSecretName, err))
 			// *don't* return an error
 		}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -117,7 +117,7 @@ func kubeClientset() (*kubernetes.Clientset, error) {
 	return clientset, err
 }
 
-// GetConfigMapInterface returns a configmap interface for the namespace
+// getConfigMapInterface returns a configmap interface for the namespace
 func (sg *SecretGenerator) getConfigMapInterface() (configMapInterface, error) {
 	clientset, err := kubeClientset()
 	if err != nil {
@@ -126,7 +126,7 @@ func (sg *SecretGenerator) getConfigMapInterface() (configMapInterface, error) {
 	return clientset.CoreV1().ConfigMaps(sg.Namespace), nil
 }
 
-// GetSecretInterface returns a secrets interface for the namespace
+// getSecretInterface returns a secrets interface for the namespace
 func (sg *SecretGenerator) getSecretInterface() (secretInterface, error) {
 	clientset, err := kubeClientset()
 	if err != nil {
@@ -149,7 +149,7 @@ func defaultConfig(name string) *v1.ConfigMap {
 	}
 }
 
-// GetSecretConfig returns the configmap containing the secrets configuration
+// getSecretConfig returns the configmap containing the secrets configuration
 func (sg *SecretGenerator) getSecretConfig(c configMapInterface) (*v1.ConfigMap, error) {
 	configMap, err := c.Get(sg.SecretsConfigMapName, metav1.GetOptions{})
 	if err == nil && configMap.Data[configVersion] == "" {
@@ -179,8 +179,7 @@ func (sg *SecretGenerator) getSecretConfig(c configMapInterface) (*v1.ConfigMap,
 	return configMap, err
 }
 
-// GetSecret returns a new Secret object initialized with the data
-// of the currently active secrets
+// getSecret returns a new Secret object initialized with the data of the currently active secrets
 func (sg *SecretGenerator) getSecret(s secretInterface, configMap *v1.ConfigMap) (*v1.Secret, error) {
 	currentName := configMap.Data[currentSecretName]
 
@@ -234,7 +233,7 @@ func (sg *SecretGenerator) expandTemplates(manifest model.Manifest) error {
 	return nil
 }
 
-// GenerateSecret will generate all secrets defined in the manifest that don't already exist
+// generateSecret will generate all secrets defined in the manifest that don't already exist
 // in the secret. If secrets rotation is triggered, then all secrets not marked as immutable
 // in the manifest will be regenerated.
 func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.Secret, configMap *v1.ConfigMap) error {
@@ -328,7 +327,7 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 	return nil
 }
 
-// UpdateSecret creates the new Secret object and records the new name in the configmap.
+// updateSecret creates the new Secret object and records the new name in the configmap.
 // The current secrets become the previous secrets, and any previous previous secrets will
 // be deleted. The configmap object in Kube is then updated to match the new configuration.
 func (sg *SecretGenerator) updateSecret(s secretInterface, secrets *v1.Secret, c configMapInterface, configMap *v1.ConfigMap) error {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -331,7 +331,10 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 			}
 
 		case model.GeneratorTypeSSH:
-			ssh.RecordKeyInfo(sshKeys, configVar)
+			err := ssh.RecordKeyInfo(sshKeys, configVar)
+			if err != nil {
+				return err
+			}
 
 		default:
 			log.Printf("Warning: variable `%s` has unknown generator type `%s`\n", configVar.Name, configVar.Generator.Type)
@@ -339,7 +342,7 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 	}
 
 	log.Println("Generate SSH keys...")
-	err := ssh.GenerateKeys(sshKeys, secrets)
+	err := ssh.GenerateAllKeys(sshKeys, secrets)
 	if err != nil {
 		return err
 	}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -40,14 +40,14 @@ const generatorSuffix = ".generator"
 
 // SecretGenerator contains all global state for creating new secrets
 type SecretGenerator struct {
-	Domain               string
-	Namespace            string
-	SecretsName          string
-	SecretsGeneration    string
-	SecretsConfigMapName string
 	CertExpiration       int
-	IsInstall            bool
 	ClusterDomain        string
+	Domain               string
+	IsInstall            bool
+	Namespace            string
+	SecretsConfigMapName string
+	SecretsGeneration    string
+	SecretsName          string
 }
 
 // Generate will fetch the current secrets, generate any missing values, and writes the new secrets
@@ -238,8 +238,8 @@ func (sg *SecretGenerator) getSecret(s secretInterface, configMap *v1.ConfigMap)
 func (sg *SecretGenerator) expandTemplates(manifest model.Manifest) error {
 	mapping := map[string]string{
 		"DOMAIN":                    sg.Domain,
-		"KUBERNETES_NAMESPACE":      sg.Namespace,
 		"KUBERNETES_CLUSTER_DOMAIN": sg.ClusterDomain,
+		"KUBERNETES_NAMESPACE":      sg.Namespace,
 	}
 	for _, configVar := range manifest.Configuration.Variables {
 		if configVar.Generator == nil {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -325,7 +325,10 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 			password.GeneratePassword(secrets, configVar.Name)
 
 		case model.GeneratorTypeCACertificate, model.GeneratorTypeCertificate:
-			ssl.RecordCertInfo(certInfo, configVar)
+			err := ssl.RecordCertInfo(certInfo, configVar)
+			if err != nil {
+				return err
+			}
 
 		case model.GeneratorTypeSSH:
 			ssh.RecordKeyInfo(sshKeys, configVar)
@@ -341,9 +344,11 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 		return err
 	}
 
-	log.Println("Generate SSL ...")
-
-	ssl.GenerateCerts(certInfo, sg.Namespace, sg.ClusterDomain, sg.CertExpiration, secrets)
+	log.Println("Generate SSL certs and keys...")
+	err = ssl.GenerateCerts(certInfo, sg.Namespace, sg.ClusterDomain, sg.CertExpiration, secrets)
+	if err != nil {
+		return err
+	}
 
 	if !sg.IsInstall {
 		log.Println("Removing secrets that are no longer being used")

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -146,8 +146,7 @@ func defaultConfig(name string) *v1.ConfigMap {
 			Name: name,
 		},
 		Data: map[string]string{
-			configVersionKey:           currentConfigVersion,
-			currentSecretGenerationKey: "0",
+			configVersionKey: currentConfigVersion,
 		},
 	}
 }
@@ -266,7 +265,9 @@ func (sg *SecretGenerator) expandTemplates(manifest model.Manifest) error {
 // in the manifest will be regenerated.
 func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.Secret, configMap *v1.ConfigMap) error {
 	if sg.SecretsGeneration != configMap.Data[currentSecretGenerationKey] {
-		log.Printf("Rotating secrets; generation `%s` -> `%s`\n", configMap.Data[currentSecretGenerationKey], sg.SecretsGeneration)
+		if len(configMap.Data[currentSecretGenerationKey]) > 0 {
+			log.Printf("Rotating secrets; generation `%s` -> `%s`\n", configMap.Data[currentSecretGenerationKey], sg.SecretsGeneration)
+		}
 
 		immutable := make(map[string]bool)
 		for _, configVar := range manifest.Configuration.Variables {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -42,12 +42,12 @@ const generatorSuffix = ".generator"
 type SecretGenerator struct {
 	Domain               string
 	Namespace            string
-	ServiceDomainSuffix  string
 	SecretsName          string
 	SecretsGeneration    string
 	SecretsConfigMapName string
 	CertExpiration       int
 	IsInstall            bool
+	ClusterDomain        string
 }
 
 // Generate will fetch the current secrets, generate any missing values, and writes the new secrets
@@ -237,9 +237,9 @@ func (sg *SecretGenerator) getSecret(s secretInterface, configMap *v1.ConfigMap)
 
 func (sg *SecretGenerator) expandTemplates(manifest model.Manifest) error {
 	mapping := map[string]string{
-		"DOMAIN":                     sg.Domain,
-		"KUBERNETES_NAMESPACE":       sg.Namespace,
-		"KUBE_SERVICE_DOMAIN_SUFFIX": sg.ServiceDomainSuffix,
+		"DOMAIN":                    sg.Domain,
+		"KUBERNETES_NAMESPACE":      sg.Namespace,
+		"KUBERNETES_CLUSTER_DOMAIN": sg.ClusterDomain,
 	}
 	for _, configVar := range manifest.Configuration.Variables {
 		if configVar.Generator == nil {
@@ -343,7 +343,7 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 
 	log.Println("Generate SSL ...")
 
-	ssl.GenerateCerts(certInfo, sg.Namespace, sg.ServiceDomainSuffix, sg.CertExpiration, secrets)
+	ssl.GenerateCerts(certInfo, sg.Namespace, sg.ClusterDomain, sg.CertExpiration, secrets)
 
 	if !sg.IsInstall {
 		log.Println("Removing secrets that are no longer being used")

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -335,10 +335,10 @@ func (sg *SecretGenerator) generateSecret(manifest model.Manifest, secrets *v1.S
 		}
 	}
 
-	log.Println("Generate SSH ...")
-
-	for _, key := range sshKeys {
-		ssh.GenerateKey(secrets, key)
+	log.Println("Generate SSH keys...")
+	err := ssh.GenerateKeys(sshKeys, secrets)
+	if err != nil {
+		return err
 	}
 
 	log.Println("Generate SSL ...")

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -891,11 +891,13 @@ func TestMigrateRenamedVariable(t *testing.T) {
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 		secrets.Data["previous-name"] = []byte("value1")
+		secrets.Data["previous-name"+generatorSuffix] = []byte("generator1")
 
 		configVar := &model.ConfigurationVariable{Name: "NEW_NAME", PreviousNames: []string{"PREVIOUS_NAME"}}
 		migrateRenamedVariable(secrets, configVar)
 		assert.Equal(t, "value1", string(secrets.Data["new-name"]),
 			"If `name` has a previous name, then it should copy the previous value")
+		assert.Equal(t, "generator1", string(secrets.Data["new-name"+generatorSuffix]))
 	})
 
 	t.Run("NewValueAlreadyExists", func(t *testing.T) {
@@ -903,12 +905,14 @@ func TestMigrateRenamedVariable(t *testing.T) {
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 		secrets.Data["previous-name"] = []byte("value1")
+		secrets.Data["previous-name"+generatorSuffix] = []byte("generator1")
 		secrets.Data["new-name"] = []byte("value2")
 
 		configVar := &model.ConfigurationVariable{Name: "NEW_NAME", PreviousNames: []string{"PREVIOUS_NAME"}}
 		migrateRenamedVariable(secrets, configVar)
 		assert.Equal(t, "value2", string(secrets.Data["new-name"]),
 			"If `name` has a value, then it should not be changed")
+		assert.Empty(t, secrets.Data["new-name"+generatorSuffix])
 	})
 
 	t.Run("MultiplePreviousNames", func(t *testing.T) {
@@ -916,12 +920,15 @@ func TestMigrateRenamedVariable(t *testing.T) {
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 		secrets.Data["previous-name"] = []byte("value1")
+		secrets.Data["previous-name"+generatorSuffix] = []byte("generator1")
 		secrets.Data["previous-previous-name"] = []byte("value2")
+		secrets.Data["previous-previous-name"+generatorSuffix] = []byte("generator2")
 
 		configVar := &model.ConfigurationVariable{Name: "NEW_NAME", PreviousNames: []string{"PREVIOUS_NAME", "PREVIOUS_PREVIOUS_NAME"}}
 		migrateRenamedVariable(secrets, configVar)
 		assert.Equal(t, "value1", string(secrets.Data["new-name"]),
 			"If `name` has multiple previous names, then it should copy the first previous value")
+		assert.Equal(t, "generator1", string(secrets.Data["new-name"+generatorSuffix]))
 	})
 
 	t.Run("MultiplePreviousNamesMissingSomeValues", func(t *testing.T) {
@@ -929,11 +936,13 @@ func TestMigrateRenamedVariable(t *testing.T) {
 
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 		secrets.Data["previous-previous-name"] = []byte("value2")
+		secrets.Data["previous-previous-name"+generatorSuffix] = []byte("generator2")
 
 		configVar := &model.ConfigurationVariable{Name: "NEW_NAME", PreviousNames: []string{"PREVIOUS_NAME", "PREVIOUS_PREVIOUS_NAME"}}
 		migrateRenamedVariable(secrets, configVar)
 		assert.Equal(t, "value2", string(secrets.Data["new-name"]),
 			"If `name` has multiple previous names, then it should copy the first non-empty previous value")
+		assert.Equal(t, "generator2", string(secrets.Data["new-name"+generatorSuffix]))
 	})
 }
 

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -129,12 +129,12 @@ func testingSecretGenerator() SecretGenerator {
 	return SecretGenerator{
 		Domain:               "domain",
 		Namespace:            "namespace",
-		ServiceDomainSuffix:  "suffix",
 		SecretsName:          "new-secret",
 		SecretsGeneration:    "1",
 		SecretsConfigMapName: "already-exists",
 		CertExpiration:       365,
 		IsInstall:            false,
+		ClusterDomain:        "cluster.domain",
 	}
 }
 
@@ -474,7 +474,7 @@ func TestExpandTemplates(t *testing.T) {
 						SubjectNames: []string{
 							"*.{{.DOMAIN}}",
 							"foo.{{.KUBERNETES_NAMESPACE}}",
-							"svc.{{.KUBE_SERVICE_DOMAIN_SUFFIX}}"},
+							"svc.{{.KUBERNETES_CLUSTER_DOMAIN}}"},
 					},
 				},
 			},
@@ -489,7 +489,7 @@ func TestExpandTemplates(t *testing.T) {
 	assert.Len(t, names, 3)
 	assert.Equal(t, "*.domain", names[0])
 	assert.Equal(t, "foo.namespace", names[1])
-	assert.Equal(t, "svc.suffix", names[2])
+	assert.Equal(t, "svc.cluster.domain", names[2])
 }
 
 func TestGenerateSecret(t *testing.T) {

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -523,8 +523,9 @@ func TestGenerateSecret(t *testing.T) {
 
 		assert.Equal(t, []byte("obsolete"), secrets.Data["non-generated"])
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.Empty(t, secrets.Data["non-generated"])
 	})
 
@@ -558,8 +559,9 @@ func TestGenerateSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["dirty"])
 		assert.Empty(t, secrets.Data["dirty"+generatorSuffix])
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["dirty"])
 		assert.NotEmpty(t, secrets.Data["dirty"+generatorSuffix])
 	})
@@ -595,8 +597,9 @@ func TestGenerateSecret(t *testing.T) {
 		generatorInput := secrets.Data["clean"+generatorSuffix]
 		assert.NotEmpty(t, generatorInput)
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.Equal(t, []byte("clean"), secrets.Data["clean"])
 		assert.Equal(t, generatorInput, secrets.Data["clean"+generatorSuffix])
 	})
@@ -632,8 +635,9 @@ func TestGenerateSecret(t *testing.T) {
 		generatorInput := secrets.Data["clean"+generatorSuffix]
 
 		sg.SecretsGeneration = "2"
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["clean"])
 		assert.NotEqual(t, []byte("clean"), secrets.Data["clean"])
 		assert.Equal(t, generatorInput, secrets.Data["clean"+generatorSuffix],
@@ -671,8 +675,9 @@ func TestGenerateSecret(t *testing.T) {
 		setSecret(secrets, manifest.Configuration.Variables[0], "clean")
 
 		sg.SecretsGeneration = "2"
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.Equal(t, []byte("clean"), secrets.Data["clean"])
 	})
 
@@ -719,8 +724,9 @@ func TestGenerateSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["ssh-key-fingerprint"])
 		assert.Empty(t, secrets.Data["ssh-key-fingerprint"+generatorSuffix])
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ssh-key"])
 		assert.NotEmpty(t, secrets.Data["ssh-key"+generatorSuffix])
 		assert.NotEmpty(t, secrets.Data["ssh-key-fingerprint"])
@@ -768,8 +774,9 @@ func TestGenerateSecret(t *testing.T) {
 		setSecret(secrets, manifest.Configuration.Variables[0], "key")
 		setSecret(secrets, manifest.Configuration.Variables[1], "fingerprint")
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.Equal(t, []byte("key"), secrets.Data["ssh-key"])
 		assert.Equal(t, []byte("fingerprint"), secrets.Data["ssh-key-fingerprint"])
 	})
@@ -817,8 +824,9 @@ func TestGenerateSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["ca-key"])
 		assert.Empty(t, secrets.Data["ca-key"+generatorSuffix])
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ca-cert"])
 		assert.NotEmpty(t, secrets.Data["ca-cert"+generatorSuffix])
 		assert.NotEmpty(t, secrets.Data["ca-key"])
@@ -866,8 +874,9 @@ func TestGenerateSecret(t *testing.T) {
 		setSecret(secrets, manifest.Configuration.Variables[0], "cert")
 		setSecret(secrets, manifest.Configuration.Variables[1], "key")
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.Equal(t, []byte("cert"), secrets.Data["ca-cert"])
 		assert.Equal(t, []byte("key"), secrets.Data["ca-key"])
 	})
@@ -933,8 +942,9 @@ func TestGenerateSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["ssl-key"])
 		assert.Empty(t, secrets.Data["ssl-key"+generatorSuffix])
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
 		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorSuffix])
 		assert.NotEmpty(t, secrets.Data["ssl-key"])
@@ -1000,8 +1010,9 @@ func TestGenerateSecret(t *testing.T) {
 		setSecret(secrets, manifest.Configuration.Variables[2], "cert")
 		setSecret(secrets, manifest.Configuration.Variables[3], "key")
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.Equal(t, []byte("cert"), secrets.Data["ssl-cert"])
 		assert.Equal(t, []byte("key"), secrets.Data["ssl-key"])
 	})
@@ -1097,8 +1108,9 @@ func TestGenerateSecret(t *testing.T) {
 		assert.Equal(t, []byte("key"), secrets.Data["ssl-key"])
 		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorSuffix])
 
-		sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(manifest, secrets, configMap)
 
+		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
 		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorSuffix])
 		assert.Contains(t, string(secrets.Data["ssl-cert"+generatorSuffix]), "subject_names")

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -171,7 +171,7 @@ func TestGetSecretConfig(t *testing.T) {
 
 		assert.Equal(t, sg.SecretsConfigMapName, configMap.Name)
 		assert.Empty(t, configMap.Data[currentSecretNameKey])
-		assert.Equal(t, "0", configMap.Data[currentSecretGenerationKey])
+		assert.Empty(t, configMap.Data[currentSecretGenerationKey])
 		assert.Equal(t, currentConfigVersion, configMap.Data[configVersionKey])
 	})
 
@@ -202,7 +202,7 @@ func TestGetSecretConfig(t *testing.T) {
 
 		assert.Equal(t, sg.SecretsConfigMapName, configMap.Name)
 		assert.Equal(t, legacySecretName, configMap.Data[currentSecretNameKey])
-		assert.Equal(t, "0", configMap.Data[currentSecretGenerationKey])
+		assert.Empty(t, configMap.Data[currentSecretGenerationKey])
 		assert.Equal(t, currentConfigVersion, configMap.Data[configVersionKey])
 	})
 

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/SUSE/scf-secret-generator/model"
@@ -12,7 +11,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type MockBase struct {
@@ -37,7 +38,8 @@ func (m *MockSecretInterface) Get(name string, options metav1.GetOptions) (*v1.S
 	m.Called(name, options)
 
 	if name == legacySecretName {
-		return nil, errors.New("missing")
+		gr := schema.GroupResource{Group: "", Resource: "test"}
+		return nil, errors.NewNotFound(gr, name)
 	}
 	secret := v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -72,7 +74,8 @@ func (m *MockConfigMapInterface) Delete(name string, options *metav1.DeleteOptio
 func (m *MockConfigMapInterface) Get(name string, options metav1.GetOptions) (*v1.ConfigMap, error) {
 	m.Called(name, options)
 	if name == defaultSecretsConfigMapName {
-		return nil, errors.New("not found")
+		gr := schema.GroupResource{Group: "", Resource: "test"}
+		return nil, errors.NewNotFound(gr, name)
 	}
 	return mockConfig(name), nil
 }

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -105,7 +105,7 @@ func mockConfig(name string) *v1.ConfigMap {
 func setSecret(secrets *v1.Secret, configVar *model.ConfigurationVariable, value string) {
 	name := util.ConvertNameToKey(configVar.Name)
 	secrets.Data[name] = []byte(value)
-	secrets.Data[name+generatorInputSuffix], _ = json.Marshal(configVar.Generator)
+	secrets.Data[name+generatorSuffix], _ = json.Marshal(configVar.Generator)
 }
 
 func testingSecretGenerator() SecretGenerator {
@@ -400,10 +400,10 @@ func TestGenerateSecret(t *testing.T) {
 		configMap := &v1.ConfigMap{Data: map[string]string{currentSecretGenerationKey: "1"}}
 
 		assert.Empty(t, secrets.Data["dirty"])
-		assert.Empty(t, secrets.Data["dirty"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["dirty"+generatorSuffix])
 		sg.generateSecret(manifest, secrets, configMap)
 		assert.NotEmpty(t, secrets.Data["dirty"])
-		assert.NotEmpty(t, secrets.Data["dirty"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["dirty"+generatorSuffix])
 	})
 
 	t.Run("Existing password isn't updated", func(t *testing.T) {
@@ -524,14 +524,14 @@ func TestGenerateSecret(t *testing.T) {
 		configMap := &v1.ConfigMap{Data: map[string]string{currentSecretGenerationKey: "1"}}
 
 		assert.Empty(t, secrets.Data["ssh-key"])
-		assert.Empty(t, secrets.Data["ssh-key"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["ssh-key"+generatorSuffix])
 		assert.Empty(t, secrets.Data["ssh-key-fingerprint"])
-		assert.Empty(t, secrets.Data["ssh-key-fingerprint"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["ssh-key-fingerprint"+generatorSuffix])
 		sg.generateSecret(manifest, secrets, configMap)
 		assert.NotEmpty(t, secrets.Data["ssh-key"])
-		assert.NotEmpty(t, secrets.Data["ssh-key"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ssh-key"+generatorSuffix])
 		assert.NotEmpty(t, secrets.Data["ssh-key-fingerprint"])
-		assert.NotEmpty(t, secrets.Data["ssh-key-fingerprint"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ssh-key-fingerprint"+generatorSuffix])
 	})
 
 	t.Run("Existing SSH key isn't updated", func(t *testing.T) {
@@ -610,14 +610,14 @@ func TestGenerateSecret(t *testing.T) {
 		configMap := &v1.ConfigMap{Data: map[string]string{currentSecretGenerationKey: "1"}}
 
 		assert.Empty(t, secrets.Data["ca-cert"])
-		assert.Empty(t, secrets.Data["ca-cert"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["ca-cert"+generatorSuffix])
 		assert.Empty(t, secrets.Data["ca-key"])
-		assert.Empty(t, secrets.Data["ca-key"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["ca-key"+generatorSuffix])
 		sg.generateSecret(manifest, secrets, configMap)
 		assert.NotEmpty(t, secrets.Data["ca-cert"])
-		assert.NotEmpty(t, secrets.Data["ca-cert"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ca-cert"+generatorSuffix])
 		assert.NotEmpty(t, secrets.Data["ca-key"])
-		assert.NotEmpty(t, secrets.Data["ca-key"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ca-key"+generatorSuffix])
 	})
 
 	t.Run("Existing SSL CA isn't updated", func(t *testing.T) {
@@ -712,14 +712,14 @@ func TestGenerateSecret(t *testing.T) {
 		configMap := &v1.ConfigMap{Data: map[string]string{currentSecretGenerationKey: "1"}}
 
 		assert.Empty(t, secrets.Data["ssl-cert"])
-		assert.Empty(t, secrets.Data["ssl-cert"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["ssl-cert"+generatorSuffix])
 		assert.Empty(t, secrets.Data["ssl-key"])
-		assert.Empty(t, secrets.Data["ssl-key"+generatorInputSuffix])
+		assert.Empty(t, secrets.Data["ssl-key"+generatorSuffix])
 		sg.generateSecret(manifest, secrets, configMap)
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
-		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorSuffix])
 		assert.NotEmpty(t, secrets.Data["ssl-key"])
-		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorSuffix])
 	})
 
 	t.Run("Existing SSL cert isn't updated", func(t *testing.T) {
@@ -860,20 +860,20 @@ func TestGenerateSecret(t *testing.T) {
 		manifest.Configuration.Variables[4].Generator.SubjectNames = []string{"*.domain"}
 
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
-		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorInputSuffix])
-		assert.NotContains(t, string(secrets.Data["ssl-cert"+generatorInputSuffix]), "subject_names")
+		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorSuffix])
+		assert.NotContains(t, string(secrets.Data["ssl-cert"+generatorSuffix]), "subject_names")
 
 		assert.NotEmpty(t, secrets.Data["ssl-key"])
-		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorSuffix])
 
 		sg.generateSecret(manifest, secrets, configMap)
 
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
-		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorInputSuffix])
-		assert.Contains(t, string(secrets.Data["ssl-cert"+generatorInputSuffix]), "subject_names")
+		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorSuffix])
+		assert.Contains(t, string(secrets.Data["ssl-cert"+generatorSuffix]), "subject_names")
 
 		assert.NotEmpty(t, secrets.Data["ssl-key"])
-		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorInputSuffix])
+		assert.NotEmpty(t, secrets.Data["ssl-key"+generatorSuffix])
 
 		assert.NotEqual(t, []byte("cert"), secrets.Data["ssl-cert"])
 		assert.NotEqual(t, []byte("key"), secrets.Data["ssl-key"])

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -127,14 +127,14 @@ func setSecret(secrets *v1.Secret, configVar *model.ConfigurationVariable, value
 
 func testingSecretGenerator() SecretGenerator {
 	return SecretGenerator{
-		Domain:               "domain",
-		Namespace:            "namespace",
-		SecretsName:          "new-secret",
-		SecretsGeneration:    "1",
-		SecretsConfigMapName: "already-exists",
 		CertExpiration:       365,
-		IsInstall:            false,
 		ClusterDomain:        "cluster.domain",
+		Domain:               "domain",
+		IsInstall:            false,
+		Namespace:            "namespace",
+		SecretsConfigMapName: "already-exists",
+		SecretsGeneration:    "1",
+		SecretsName:          "new-secret",
 	}
 }
 

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -21,6 +21,38 @@ type Key struct {
 	Fingerprint string // Name to associate with fingerprint
 }
 
+// RecordKeyInfo records priave key or fingerprint names for later generation
+func RecordKeyInfo(keys map[string]Key, configVar *model.ConfigurationVariable) error {
+	if len(configVar.Generator.ID) == 0 {
+		return fmt.Errorf("Config variable `%s` has no ID value", configVar.Name)
+	}
+	if configVar.Generator.Type != model.GeneratorTypeSSH {
+		return fmt.Errorf("Config variable `%s` does not have a valid SSH generator type", configVar.Name)
+	}
+
+	// Get or create the key from the map, there should always be
+	// a pair of private keys and fingerprints
+	key := keys[configVar.Generator.ID]
+
+	switch configVar.Generator.ValueType {
+	case model.ValueTypeFingerprint:
+		if len(key.Fingerprint) > 0 {
+			return fmt.Errorf("Multiple variables define fingerprints name for SSH id `%s`", configVar.Generator.ID)
+		}
+		key.Fingerprint = configVar.Name
+	case model.ValueTypePrivateKey:
+		if len(key.PrivateKey) > 0 {
+			return fmt.Errorf("Multiple variables define private key name for SSH id `%s`", configVar.Generator.ID)
+		}
+		key.PrivateKey = configVar.Name
+	default:
+		return fmt.Errorf("Config variable `%s` has invalid value type `%s`", configVar.Name, configVar.Generator.ValueType)
+	}
+
+	keys[configVar.Generator.ID] = key
+	return nil
+}
+
 // GenerateAllKeys will create private keys and fingerprints for all recorded SSH variables
 func GenerateAllKeys(keys map[string]Key, secrets *v1.Secret) error {
 	for id, key := range keys {
@@ -72,37 +104,5 @@ func generateKey(secrets *v1.Secret, key Key) error {
 	secrets.Data[secretKey] = pem.EncodeToMemory(privateBlock)
 	secrets.Data[fingerprintKey] = []byte(ssh.FingerprintLegacyMD5(public))
 
-	return nil
-}
-
-// RecordKeyInfo records priave key or fingerprint names for later generation
-func RecordKeyInfo(keys map[string]Key, configVar *model.ConfigurationVariable) error {
-	if len(configVar.Generator.ID) == 0 {
-		return fmt.Errorf("Config variable `%s` has no ID value", configVar.Name)
-	}
-	if configVar.Generator.Type != model.GeneratorTypeSSH {
-		return fmt.Errorf("Config variable `%s` does not have a valid SSH generator type", configVar.Name)
-	}
-
-	// Get or create the key from the map, there should always be
-	// a pair of private keys and fingerprints
-	key := keys[configVar.Generator.ID]
-
-	switch configVar.Generator.ValueType {
-	case model.ValueTypeFingerprint:
-		if len(key.Fingerprint) > 0 {
-			return fmt.Errorf("Multiple variables define fingerprints name for SSH id `%s`", configVar.Generator.ID)
-		}
-		key.Fingerprint = configVar.Name
-	case model.ValueTypePrivateKey:
-		if len(key.PrivateKey) > 0 {
-			return fmt.Errorf("Multiple variables define private key name for SSH id `%s`", configVar.Generator.ID)
-		}
-		key.PrivateKey = configVar.Name
-	default:
-		return fmt.Errorf("Config variable `%s` has invalid value type `%s`", configVar.Name, configVar.Generator.ValueType)
-	}
-
-	keys[configVar.Generator.ID] = key
 	return nil
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -9,115 +9,6 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func TestGenerateKey(t *testing.T) {
-	t.Parallel()
-
-	t.Run("New key is created", func(t *testing.T) {
-
-		t.Parallel()
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-
-		key := Key{
-			PrivateKey:  "foo",
-			Fingerprint: "bar",
-		}
-
-		err := generateKey(secrets, key)
-
-		require.NoError(t, err)
-		assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
-		assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
-
-		// 16 colon separated bytes = 47
-		// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
-		assert.Len(t, secrets.Data["bar"], 47)
-	})
-
-	t.Run("Existing key is not changed", func(t *testing.T) {
-		t.Parallel()
-
-		fooData := []byte("foo-data")
-		barData := []byte("bar-data")
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-
-		// Also tests for FOO / foo case conversion
-		secrets.Data["foo"] = fooData
-		secrets.Data["bar"] = barData
-
-		key := Key{
-			PrivateKey:  "FOO",
-			Fingerprint: "BAR",
-		}
-
-		err := generateKey(secrets, key)
-
-		require.NoError(t, err)
-		assert.Equal(t, fooData, secrets.Data["foo"])
-		assert.Equal(t, barData, secrets.Data["bar"])
-	})
-}
-
-func TestGenerateAllKeys(t *testing.T) {
-	t.Parallel()
-
-	t.Run("Generate keys", func(t *testing.T) {
-		t.Parallel()
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-
-		keys := map[string]Key{
-			"mysshkey": Key{
-				PrivateKey:  "foo",
-				Fingerprint: "bar",
-			},
-		}
-
-		err := GenerateAllKeys(keys, secrets)
-
-		require.NoError(t, err)
-		assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
-		assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
-
-		// 16 colon separated bytes = 47
-		// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
-		assert.Len(t, secrets.Data["bar"], 47)
-	})
-
-	t.Run("Missing private key", func(t *testing.T) {
-		t.Parallel()
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-
-		keys := map[string]Key{
-			"mysshkey": Key{
-				Fingerprint: "bar",
-			},
-		}
-
-		err := GenerateAllKeys(keys, secrets)
-
-		assert.EqualError(t, err, "No private key name defined for SSH id `mysshkey`")
-	})
-
-	t.Run("Missing fingerprint", func(t *testing.T) {
-		t.Parallel()
-
-		secrets := &v1.Secret{Data: map[string][]byte{}}
-
-		keys := map[string]Key{
-			"mysshkey": Key{
-				PrivateKey: "foo",
-			},
-		}
-
-		err := GenerateAllKeys(keys, secrets)
-
-		assert.EqualError(t, err, "No fingerprint name defined for SSH id `mysshkey`")
-	})
-}
-
 func TestRecordKeyInfo(t *testing.T) {
 	t.Parallel()
 
@@ -293,5 +184,114 @@ func TestRecordKeyInfo(t *testing.T) {
 		err = RecordKeyInfo(keys, configVar)
 
 		assert.EqualError(t, err, "Multiple variables define private key name for SSH id `foo`")
+	})
+}
+
+func TestGenerateAllKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Generate keys", func(t *testing.T) {
+		t.Parallel()
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		keys := map[string]Key{
+			"mysshkey": Key{
+				PrivateKey:  "foo",
+				Fingerprint: "bar",
+			},
+		}
+
+		err := GenerateAllKeys(keys, secrets)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
+		assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
+
+		// 16 colon separated bytes = 47
+		// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
+		assert.Len(t, secrets.Data["bar"], 47)
+	})
+
+	t.Run("Missing private key", func(t *testing.T) {
+		t.Parallel()
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		keys := map[string]Key{
+			"mysshkey": Key{
+				Fingerprint: "bar",
+			},
+		}
+
+		err := GenerateAllKeys(keys, secrets)
+
+		assert.EqualError(t, err, "No private key name defined for SSH id `mysshkey`")
+	})
+
+	t.Run("Missing fingerprint", func(t *testing.T) {
+		t.Parallel()
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		keys := map[string]Key{
+			"mysshkey": Key{
+				PrivateKey: "foo",
+			},
+		}
+
+		err := GenerateAllKeys(keys, secrets)
+
+		assert.EqualError(t, err, "No fingerprint name defined for SSH id `mysshkey`")
+	})
+}
+
+func TestGenerateKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("New key is created", func(t *testing.T) {
+
+		t.Parallel()
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		key := Key{
+			PrivateKey:  "foo",
+			Fingerprint: "bar",
+		}
+
+		err := generateKey(secrets, key)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
+		assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
+
+		// 16 colon separated bytes = 47
+		// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
+		assert.Len(t, secrets.Data["bar"], 47)
+	})
+
+	t.Run("Existing key is not changed", func(t *testing.T) {
+		t.Parallel()
+
+		fooData := []byte("foo-data")
+		barData := []byte("bar-data")
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		// Also tests for FOO / foo case conversion
+		secrets.Data["foo"] = fooData
+		secrets.Data["bar"] = barData
+
+		key := Key{
+			PrivateKey:  "FOO",
+			Fingerprint: "BAR",
+		}
+
+		err := generateKey(secrets, key)
+
+		require.NoError(t, err)
+		assert.Equal(t, fooData, secrets.Data["foo"])
+		assert.Equal(t, barData, secrets.Data["bar"])
 	})
 }

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -1,155 +1,297 @@
 package ssh
 
-// create a key if not found
-// update key if found
-// how to test generating the keys?
-
 import (
 	"testing"
 
 	"github.com/SUSE/scf-secret-generator/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 )
 
-// generateKey tests
-
-func TestNewKeyIsCreated(t *testing.T) {
+func TestGenerateKey(t *testing.T) {
 	t.Parallel()
 
-	secrets := &v1.Secret{Data: map[string][]byte{}}
+	t.Run("New key is created", func(t *testing.T) {
 
-	key := Key{
-		PrivateKey:  "foo",
-		Fingerprint: "bar",
-	}
+		t.Parallel()
 
-	err := generateKey(secrets, key)
+		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-	assert.NoError(t, err)
-	assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
-	assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
-
-	// 16 colon separated bytes = 47
-	// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
-	assert.Len(t, secrets.Data["bar"], 47)
-}
-
-func TestExistingKeyIsNotChanged(t *testing.T) {
-	t.Parallel()
-
-	fooData := []byte("foo-data")
-	barData := []byte("bar-data")
-
-	secrets := &v1.Secret{Data: map[string][]byte{}}
-
-	// Also tests for FOO / foo case conversion
-	secrets.Data["foo"] = fooData
-	secrets.Data["bar"] = barData
-
-	key := Key{
-		PrivateKey:  "FOO",
-		Fingerprint: "BAR",
-	}
-
-	err := generateKey(secrets, key)
-
-	assert.NoError(t, err)
-	assert.Equal(t, fooData, secrets.Data["foo"])
-	assert.Equal(t, barData, secrets.Data["bar"])
-}
-
-// GenerateKey tests
-
-func TestGenerateKeys(t *testing.T) {
-	t.Parallel()
-
-	secrets := &v1.Secret{Data: map[string][]byte{}}
-
-	keys := map[string]Key{
-		"mysshkey": Key{
+		key := Key{
 			PrivateKey:  "foo",
 			Fingerprint: "bar",
-		},
-	}
+		}
 
-	err := GenerateKeys(keys, secrets)
+		err := generateKey(secrets, key)
 
-	assert.NoError(t, err)
-	assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
-	assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
+		require.NoError(t, err)
+		assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
+		assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
 
-	// 16 colon separated bytes = 47
-	// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
-	assert.Len(t, secrets.Data["bar"], 47)
+		// 16 colon separated bytes = 47
+		// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
+		assert.Len(t, secrets.Data["bar"], 47)
+	})
+
+	t.Run("Existing key is not changed", func(t *testing.T) {
+		t.Parallel()
+
+		fooData := []byte("foo-data")
+		barData := []byte("bar-data")
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		// Also tests for FOO / foo case conversion
+		secrets.Data["foo"] = fooData
+		secrets.Data["bar"] = barData
+
+		key := Key{
+			PrivateKey:  "FOO",
+			Fingerprint: "BAR",
+		}
+
+		err := generateKey(secrets, key)
+
+		require.NoError(t, err)
+		assert.Equal(t, fooData, secrets.Data["foo"])
+		assert.Equal(t, barData, secrets.Data["bar"])
+	})
 }
 
-func TestMissingPrivateKey(t *testing.T) {
+func TestGenerateAllKeys(t *testing.T) {
 	t.Parallel()
 
-	secrets := &v1.Secret{Data: map[string][]byte{}}
+	t.Run("Generate keys", func(t *testing.T) {
+		t.Parallel()
 
-	keys := map[string]Key{
-		"mysshkey": Key{
-			Fingerprint: "bar",
-		},
-	}
+		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-	err := GenerateKeys(keys, secrets)
+		keys := map[string]Key{
+			"mysshkey": Key{
+				PrivateKey:  "foo",
+				Fingerprint: "bar",
+			},
+		}
 
-	assert.EqualError(t, err, "No private key name defined for SSH id `mysshkey`")
+		err := GenerateAllKeys(keys, secrets)
+
+		require.NoError(t, err)
+		assert.Contains(t, string(secrets.Data["foo"]), "BEGIN RSA PRIVATE KEY")
+		assert.Contains(t, string(secrets.Data["foo"]), "END RSA PRIVATE KEY")
+
+		// 16 colon separated bytes = 47
+		// 00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff
+		assert.Len(t, secrets.Data["bar"], 47)
+	})
+
+	t.Run("Missing private key", func(t *testing.T) {
+		t.Parallel()
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		keys := map[string]Key{
+			"mysshkey": Key{
+				Fingerprint: "bar",
+			},
+		}
+
+		err := GenerateAllKeys(keys, secrets)
+
+		assert.EqualError(t, err, "No private key name defined for SSH id `mysshkey`")
+	})
+
+	t.Run("Missing fingerprint", func(t *testing.T) {
+		t.Parallel()
+
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		keys := map[string]Key{
+			"mysshkey": Key{
+				PrivateKey: "foo",
+			},
+		}
+
+		err := GenerateAllKeys(keys, secrets)
+
+		assert.EqualError(t, err, "No fingerprint name defined for SSH id `mysshkey`")
+	})
 }
 
-func TestMissingFingerprint(t *testing.T) {
+func TestRecordKeyInfo(t *testing.T) {
 	t.Parallel()
 
-	secrets := &v1.Secret{Data: map[string][]byte{}}
+	t.Run("Recording fingerprint creates key", func(t *testing.T) {
+		t.Parallel()
 
-	keys := map[string]Key{
-		"mysshkey": Key{
-			PrivateKey: "foo",
-		},
-	}
+		keys := make(map[string]Key)
 
-	err := GenerateKeys(keys, secrets)
+		configVar := &model.ConfigurationVariable{
+			Name: "FINGERPRINT_NAME",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypeSSH,
+			ValueType: model.ValueTypeFingerprint,
+		}
 
-	assert.EqualError(t, err, "No fingerprint name defined for SSH id `mysshkey`")
-}
+		err := RecordKeyInfo(keys, configVar)
 
-// RecordKeyInfo tests
+		require.NoError(t, err)
+		assert.Equal(t, "FINGERPRINT_NAME", keys["foo"].Fingerprint)
+	})
 
-func TestRecordingFingerprintCreatesKey(t *testing.T) {
-	t.Parallel()
+	t.Run("Recording private key creates key", func(t *testing.T) {
+		t.Parallel()
 
-	keys := make(map[string]Key)
+		keys := make(map[string]Key)
 
-	configVar := &model.ConfigurationVariable{
-		Name: "FINGERPRINT_NAME",
-	}
-	configVar.Generator = &model.ConfigurationVariableGenerator{
-		ID:        "foo",
-		ValueType: model.ValueTypeFingerprint,
-	}
+		configVar := &model.ConfigurationVariable{
+			Name: "PRIVATE_KEY_NAME",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypeSSH,
+			ValueType: model.ValueTypePrivateKey,
+		}
 
-	RecordKeyInfo(keys, configVar)
+		err := RecordKeyInfo(keys, configVar)
 
-	assert.Equal(t, "FINGERPRINT_NAME", keys["foo"].Fingerprint)
-}
+		require.NoError(t, err)
+		assert.Equal(t, "PRIVATE_KEY_NAME", keys["foo"].PrivateKey)
+	})
 
-func TestRecordingPrivateCreatesKey(t *testing.T) {
-	t.Parallel()
+	t.Run("Fingerprint and private key are stored in the same record", func(t *testing.T) {
+		t.Parallel()
 
-	keys := make(map[string]Key)
+		keys := make(map[string]Key)
 
-	configVar := &model.ConfigurationVariable{
-		Name: "PRIVATE_KEY_NAME",
-	}
-	configVar.Generator = &model.ConfigurationVariableGenerator{
-		ID:        "foo",
-		ValueType: model.ValueTypePrivateKey,
-	}
+		configVar := &model.ConfigurationVariable{
+			Name: "FINGERPRINT_NAME",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypeSSH,
+			ValueType: model.ValueTypeFingerprint,
+		}
 
-	RecordKeyInfo(keys, configVar)
+		err := RecordKeyInfo(keys, configVar)
 
-	assert.Equal(t, "PRIVATE_KEY_NAME", keys["foo"].PrivateKey)
+		require.NoError(t, err)
+
+		configVar.Name = "PRIVATE_KEY_NAME"
+		configVar.Generator.ValueType = model.ValueTypePrivateKey
+
+		err = RecordKeyInfo(keys, configVar)
+
+		require.NoError(t, err)
+		assert.Equal(t, "FINGERPRINT_NAME", keys["foo"].Fingerprint)
+		assert.Equal(t, "PRIVATE_KEY_NAME", keys["foo"].PrivateKey)
+	})
+
+	t.Run("Generator has no ID", func(t *testing.T) {
+		t.Parallel()
+
+		keys := make(map[string]Key)
+
+		configVar := &model.ConfigurationVariable{
+			Name: "FINGERPRINT_NAME",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			Type:      model.GeneratorTypeSSH,
+			ValueType: model.ValueTypeFingerprint,
+		}
+
+		err := RecordKeyInfo(keys, configVar)
+
+		assert.EqualError(t, err, "Config variable `FINGERPRINT_NAME` has no ID value")
+	})
+
+	t.Run("Generator has invalid type", func(t *testing.T) {
+		t.Parallel()
+
+		keys := make(map[string]Key)
+
+		configVar := &model.ConfigurationVariable{
+			Name: "FINGERPRINT_NAME",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypePassword,
+			ValueType: model.ValueTypeFingerprint,
+		}
+
+		err := RecordKeyInfo(keys, configVar)
+
+		assert.EqualError(t, err, "Config variable `FINGERPRINT_NAME` does not have a valid SSH generator type")
+	})
+
+	t.Run("Generator has invalid value type", func(t *testing.T) {
+		t.Parallel()
+
+		keys := make(map[string]Key)
+
+		configVar := &model.ConfigurationVariable{
+			Name: "FINGERPRINT_NAME",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypeSSH,
+			ValueType: "unknown",
+		}
+
+		err := RecordKeyInfo(keys, configVar)
+
+		assert.EqualError(t, err, "Config variable `FINGERPRINT_NAME` has invalid value type `unknown`")
+	})
+
+	t.Run("Fingerprint has multiple definitions", func(t *testing.T) {
+		t.Parallel()
+
+		keys := make(map[string]Key)
+
+		configVar := &model.ConfigurationVariable{
+			Name: "FINGERPRINT_NAME1",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypeSSH,
+			ValueType: model.ValueTypeFingerprint,
+		}
+
+		err := RecordKeyInfo(keys, configVar)
+
+		require.NoError(t, err)
+
+		configVar.Name = "FINGERPRINT_NAME2"
+
+		err = RecordKeyInfo(keys, configVar)
+
+		assert.EqualError(t, err, "Multiple variables define fingerprints name for SSH id `foo`")
+	})
+
+	t.Run("Private key has multiple definitions", func(t *testing.T) {
+		t.Parallel()
+
+		keys := make(map[string]Key)
+
+		configVar := &model.ConfigurationVariable{
+			Name: "PRIVATE_KEY_NAME1",
+		}
+		configVar.Generator = &model.ConfigurationVariableGenerator{
+			ID:        "foo",
+			Type:      model.GeneratorTypeSSH,
+			ValueType: model.ValueTypePrivateKey,
+		}
+
+		err := RecordKeyInfo(keys, configVar)
+
+		require.NoError(t, err)
+
+		configVar.Name = "PRIVATE_KEY_NAME2"
+
+		err = RecordKeyInfo(keys, configVar)
+
+		assert.EqualError(t, err, "Multiple variables define private key name for SSH id `foo`")
+	})
 }


### PR DESCRIPTION
The new `-isInstall` option should be set from the helm `.Release.IsInstall` property, so the generator has the definitive information whether this is an install or an upgrade.

It will now fail early if this is an upgrade, but the previous secret cannot be found, instead of assuming that it is a fresh install. Similarly, it will always delete any existing objects before creating them, so it will not fail due to left-over objects from a previous installation.

It will also now try to do an "empty" update of the configmap, so it will fail before creating the secret object if it cannot update the configmap for whatever reason.

This PR also implements "updates" to the previously installed version by simply swapping the current and previous secret names in the configmap.