### PR TITLE
Use BOSH manifests variable section

### DIFF
--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -20,5 +20,76 @@ func TestManifestConfigurationSectionNotFound(t *testing.T) {
 
 	_, err := GetManifest(strings.NewReader("roles: []"))
 
-	assert.EqualError(t, err, "'configuration section' not found in manifest")
+	assert.EqualError(t, err, "'Variables section' not found in manifest")
+}
+
+var exampleManifest = `
+instance_groups: []
+variables:
+- { name: "a", type: "password" }
+- name: "b"
+  type: "certificate"
+  options:
+    secret: true
+    ca: "default_ca"
+    common_name: "example.com"
+    alternative_names: ["other"]
+- name: "c"
+  type: "ssh"
+  options: { description: "for example", required: true }
+- name: APP_SSH_KEY
+  options:
+    secret: true
+    description: PEM encoded RSA private key used to identify host.
+    required: true  
+`
+
+var duplicateNameManifest = `
+instance_groups: []
+variables:
+- { name: "a", type: "password" }
+- { name: "a", type: "ssh" }
+- name: APP_SSH_KEY
+  options:
+    secret: true
+    description: PEM encoded RSA private key used to identify host.
+    required: true  
+`
+
+func TestManifestConfigurationHasOptions(t *testing.T) {
+	t.Parallel()
+
+	m, err := GetManifest(strings.NewReader(exampleManifest))
+	assert.NoError(t, err)
+
+	for _, v := range m.Variables {
+		assert.NotNil(t, v.Name)
+	}
+	v := m.Variables[0]
+	assert.Equal(t, "a", v.Name)
+	assert.Equal(t, VariableTypePassword, v.Type)
+	assert.Equal(t, CVOptions{}, v.CVOptions)
+
+	v = m.Variables[1]
+	assert.Equal(t, "b", v.Name)
+	assert.Equal(t, VariableTypeCertificate, v.Type)
+	assert.Equal(t, "default_ca", v.Options["ca"])
+	assert.Equal(t, true, v.CVOptions.Secret)
+	assert.Nil(t, v.Options["secret"])
+
+	v = m.Variables[2]
+	assert.Equal(t, "c", v.Name)
+	assert.Equal(t, VariableTypeSSH, v.Type)
+	assert.Equal(t, false, v.CVOptions.Secret)
+
+	v = m.Variables[3]
+	assert.Equal(t, "APP_SSH_KEY", v.Name)
+	assert.Equal(t, EmptyType, v.Type)
+}
+
+func TestManifestUniqueNames(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetManifest(strings.NewReader(duplicateNameManifest))
+	assert.EqualError(t, err, "Duplicate variable name found in manifest")
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -22,34 +22,19 @@ type Key struct {
 }
 
 // RecordKeyInfo records priave key or fingerprint names for later generation
-func RecordKeyInfo(keys map[string]Key, configVar *model.ConfigurationVariable) error {
-	if len(configVar.Generator.ID) == 0 {
-		return fmt.Errorf("Config variable `%s` has no ID value", configVar.Name)
-	}
-	if configVar.Generator.Type != model.GeneratorTypeSSH {
+func RecordKeyInfo(keys map[string]Key, configVar *model.VariableDefinition) error {
+	if configVar.Type != model.VariableTypeSSH {
 		return fmt.Errorf("Config variable `%s` does not have a valid SSH generator type", configVar.Name)
 	}
 
 	// Get or create the key from the map, there should always be
 	// a pair of private keys and fingerprints
-	key := keys[configVar.Generator.ID]
+	key := keys[configVar.Name]
 
-	switch configVar.Generator.ValueType {
-	case model.ValueTypeFingerprint:
-		if len(key.Fingerprint) > 0 {
-			return fmt.Errorf("Multiple variables define fingerprints name for SSH id `%s`", configVar.Generator.ID)
-		}
-		key.Fingerprint = configVar.Name
-	case model.ValueTypePrivateKey:
-		if len(key.PrivateKey) > 0 {
-			return fmt.Errorf("Multiple variables define private key name for SSH id `%s`", configVar.Generator.ID)
-		}
-		key.PrivateKey = configVar.Name
-	default:
-		return fmt.Errorf("Config variable `%s` has invalid value type `%s`", configVar.Name, configVar.Generator.ValueType)
-	}
+	key.Fingerprint = configVar.Name + model.FingerprintSuffix
+	key.PrivateKey = configVar.Name
 
-	keys[configVar.Generator.ID] = key
+	keys[configVar.Name] = key
 	return nil
 }
 

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -12,178 +12,22 @@ import (
 func TestRecordKeyInfo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Recording fingerprint creates key", func(t *testing.T) {
+	t.Run("Fingerprint and private key are recorded", func(t *testing.T) {
 		t.Parallel()
 
 		keys := make(map[string]Key)
 
-		configVar := &model.ConfigurationVariable{
-			Name: "FINGERPRINT_NAME",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypeSSH,
-			ValueType: model.ValueTypeFingerprint,
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		require.NoError(t, err)
-		assert.Equal(t, "FINGERPRINT_NAME", keys["foo"].Fingerprint)
-	})
-
-	t.Run("Recording private key creates key", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "PRIVATE_KEY_NAME",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypeSSH,
-			ValueType: model.ValueTypePrivateKey,
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		require.NoError(t, err)
-		assert.Equal(t, "PRIVATE_KEY_NAME", keys["foo"].PrivateKey)
-	})
-
-	t.Run("Fingerprint and private key are stored in the same record", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "FINGERPRINT_NAME",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypeSSH,
-			ValueType: model.ValueTypeFingerprint,
+		configVar := &model.VariableDefinition{
+			Name: "foo",
+			Type: model.VariableTypeSSH,
 		}
 
 		err := RecordKeyInfo(keys, configVar)
 
 		require.NoError(t, err)
 
-		configVar.Name = "PRIVATE_KEY_NAME"
-		configVar.Generator.ValueType = model.ValueTypePrivateKey
-
-		err = RecordKeyInfo(keys, configVar)
-
-		require.NoError(t, err)
-		assert.Equal(t, "FINGERPRINT_NAME", keys["foo"].Fingerprint)
-		assert.Equal(t, "PRIVATE_KEY_NAME", keys["foo"].PrivateKey)
-	})
-
-	t.Run("Generator has no ID", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "FINGERPRINT_NAME",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			Type:      model.GeneratorTypeSSH,
-			ValueType: model.ValueTypeFingerprint,
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		assert.EqualError(t, err, "Config variable `FINGERPRINT_NAME` has no ID value")
-	})
-
-	t.Run("Generator has invalid type", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "FINGERPRINT_NAME",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypePassword,
-			ValueType: model.ValueTypeFingerprint,
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		assert.EqualError(t, err, "Config variable `FINGERPRINT_NAME` does not have a valid SSH generator type")
-	})
-
-	t.Run("Generator has invalid value type", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "FINGERPRINT_NAME",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypeSSH,
-			ValueType: "unknown",
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		assert.EqualError(t, err, "Config variable `FINGERPRINT_NAME` has invalid value type `unknown`")
-	})
-
-	t.Run("Fingerprint has multiple definitions", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "FINGERPRINT_NAME1",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypeSSH,
-			ValueType: model.ValueTypeFingerprint,
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		require.NoError(t, err)
-
-		configVar.Name = "FINGERPRINT_NAME2"
-
-		err = RecordKeyInfo(keys, configVar)
-
-		assert.EqualError(t, err, "Multiple variables define fingerprints name for SSH id `foo`")
-	})
-
-	t.Run("Private key has multiple definitions", func(t *testing.T) {
-		t.Parallel()
-
-		keys := make(map[string]Key)
-
-		configVar := &model.ConfigurationVariable{
-			Name: "PRIVATE_KEY_NAME1",
-		}
-		configVar.Generator = &model.ConfigurationVariableGenerator{
-			ID:        "foo",
-			Type:      model.GeneratorTypeSSH,
-			ValueType: model.ValueTypePrivateKey,
-		}
-
-		err := RecordKeyInfo(keys, configVar)
-
-		require.NoError(t, err)
-
-		configVar.Name = "PRIVATE_KEY_NAME2"
-
-		err = RecordKeyInfo(keys, configVar)
-
-		assert.EqualError(t, err, "Multiple variables define private key name for SSH id `foo`")
+		assert.Equal(t, "foo.fingerprint", keys["foo"].Fingerprint)
+		assert.Equal(t, "foo", keys["foo"].PrivateKey)
 	})
 }
 

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -24,19 +24,15 @@ func TestRecordCertInfo(t *testing.T) {
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-				ID:        certID,
-			},
+		configVar := &model.VariableDefinition{
+			Name:      certID,
+			Type:      model.VariableTypeCertificate,
+			CVOptions: model.CVOptions{Secret: true},
 		}
 		err := RecordCertInfo(certInfo, configVar)
 
 		require.NoError(t, err)
-		assert.Equal(t, "cert-name", certInfo[certID].CertificateName)
+		assert.Equal(t, "cert-id", certInfo[certID].CertificateName)
 	})
 
 	t.Run("Private key should be added to certInfo", func(t *testing.T) {
@@ -44,19 +40,15 @@ func TestRecordCertInfo(t *testing.T) {
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "PRIVATE_KEY_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypePrivateKey,
-				ID:        certID,
-			},
+		configVar := &model.VariableDefinition{
+			Name:      certID,
+			Type:      model.VariableTypeCertificate,
+			CVOptions: model.CVOptions{Secret: true},
 		}
 		err := RecordCertInfo(certInfo, configVar)
 
 		require.NoError(t, err)
-		assert.Equal(t, "private-key-name", certInfo[certID].PrivateKeyName)
+		assert.Equal(t, "cert-id.key", certInfo[certID].PrivateKeyName)
 	})
 
 	t.Run("Private key and cert should be in the same mapped value", func(t *testing.T) {
@@ -64,33 +56,18 @@ func TestRecordCertInfo(t *testing.T) {
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-				ID:        certID,
-			},
+		configVar := &model.VariableDefinition{
+			Name:      certID,
+			Type:      model.VariableTypeCertificate,
+			CVOptions: model.CVOptions{Secret: true},
 		}
 		err := RecordCertInfo(certInfo, configVar)
 
 		require.NoError(t, err)
 
-		configVar = &model.ConfigurationVariable{
-			Name:   "PRIVATE_KEY_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypePrivateKey,
-				ID:        certID,
-			},
-		}
-		err = RecordCertInfo(certInfo, configVar)
-
 		require.NoError(t, err)
-		assert.Equal(t, "cert-name", certInfo[certID].CertificateName)
-		assert.Equal(t, "private-key-name", certInfo[certID].PrivateKeyName)
+		assert.Equal(t, "cert-id", certInfo[certID].CertificateName)
+		assert.Equal(t, "cert-id.key", certInfo[certID].PrivateKeyName)
 	})
 
 	t.Run("SubjectNames are added to certInfo", func(t *testing.T) {
@@ -98,15 +75,13 @@ func TestRecordCertInfo(t *testing.T) {
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:         model.GeneratorTypeCertificate,
-				ValueType:    model.ValueTypeCertificate,
-				SubjectNames: []string{"subject names"},
-				ID:           certID,
+		configVar := &model.VariableDefinition{
+			Name: certID,
+			Type: model.VariableTypeCertificate,
+			Options: model.VariableOptions{
+				"alternative_names": []string{"subject names"},
 			},
+			CVOptions: model.CVOptions{Secret: true},
 		}
 		err := RecordCertInfo(certInfo, configVar)
 
@@ -119,14 +94,12 @@ func TestRecordCertInfo(t *testing.T) {
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-				RoleName:  "role name",
-				ID:        certID,
+		configVar := &model.VariableDefinition{
+			Name: certID,
+			Type: model.VariableTypeCertificate,
+			CVOptions: model.CVOptions{
+				Secret:   true,
+				RoleName: "role name",
 			},
 		}
 		err := RecordCertInfo(certInfo, configVar)
@@ -135,216 +108,23 @@ func TestRecordCertInfo(t *testing.T) {
 		assert.Equal(t, "role name", certInfo[certID].RoleName)
 	})
 
-	t.Run("Generator has no ID", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Config variable `CERT_NAME` has no ID value")
-	})
-
-	t.Run("Generator has wrong Type", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypePassword,
-				ValueType: model.ValueTypeCertificate,
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Config variable `CERT_NAME` does not have a valid SSL generator type")
-	})
-
-	t.Run("Generator has wrong Value Type", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: "undefined",
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Config variable `CERT_NAME` has invalid value type `undefined`")
-	})
-
-	t.Run("Key and cert should use the same cert type", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		require.NoError(t, err)
-
-		configVar = &model.ConfigurationVariable{
-			Name:   "PRIVATE_KEY_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCACertificate,
-				ValueType: model.ValueTypePrivateKey,
-				ID:        certID,
-			},
-		}
-		err = RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Inconsistent cert type (CA vs non-CA) between Cert and Key vars for id `cert-id`")
-	})
-
-	t.Run("Certificate has multiple definitions", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME1",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		require.NoError(t, err)
-
-		configVar = &model.ConfigurationVariable{
-			Name:   "CERT_NAME2",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypeCertificate,
-				ID:        certID,
-			},
-		}
-		err = RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Multiple variables define certificate name for SSL id `cert-id`")
-	})
-
-	t.Run("Private key has multiple definitions", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "PRIVATE_KEY_NAME1",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypePrivateKey,
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		require.NoError(t, err)
-
-		configVar = &model.ConfigurationVariable{
-			Name:   "PRIVATE_KEY_NAME2",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypePrivateKey,
-				ID:        certID,
-			},
-		}
-		err = RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Multiple variables define private key name for SSL id `cert-id`")
-	})
-
 	t.Run("SubjectNames not allowed on CA certs", func(t *testing.T) {
 		t.Parallel()
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:         model.GeneratorTypeCACertificate,
-				ValueType:    model.ValueTypeCertificate,
-				SubjectNames: []string{"subject names"},
-				ID:           certID,
+		configVar := &model.VariableDefinition{
+			Name: "CERT_NAME",
+			Type: model.VariableTypeCertificate,
+			Options: model.VariableOptions{
+				"is_ca":             true,
+				"alternative_names": []string{"subject names"},
 			},
+			CVOptions: model.CVOptions{Secret: true},
 		}
 		err := RecordCertInfo(certInfo, configVar)
 
-		assert.EqualError(t, err, "CA Cert or key for SSL id `cert-id` should not have subject names")
-	})
-
-	t.Run("SubjectNames not allowed on CA keys", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:         model.GeneratorTypeCACertificate,
-				ValueType:    model.ValueTypePrivateKey,
-				SubjectNames: []string{"subject names"},
-				ID:           certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "CA Cert or key for SSL id `cert-id` should not have subject names")
-	})
-
-	t.Run("SubjectNames not allowed on keys", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:         model.GeneratorTypeCertificate,
-				ValueType:    model.ValueTypePrivateKey,
-				SubjectNames: []string{"subject names"},
-				ID:           certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Private key for SSL id `cert-id` should not have subject names")
+		assert.EqualError(t, err, "CA Cert for SSL id `CERT_NAME` should not have subject names")
 	})
 
 	t.Run("Role name not allowed on CA certs", func(t *testing.T) {
@@ -352,60 +132,22 @@ func TestRecordCertInfo(t *testing.T) {
 
 		certInfo := make(map[string]CertInfo)
 
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCACertificate,
-				ValueType: model.ValueTypeCertificate,
-				RoleName:  "role name",
-				ID:        certID,
+		configVar := &model.VariableDefinition{
+			Name: "CERT_NAME",
+			Type: model.VariableTypeCertificate,
+			Options: model.VariableOptions{
+				"is_ca": true,
+			},
+			CVOptions: model.CVOptions{
+				Secret:   true,
+				RoleName: "role name",
 			},
 		}
 		err := RecordCertInfo(certInfo, configVar)
 
-		assert.EqualError(t, err, "CA Cert or key for SSL id `cert-id` should not have a role name")
+		assert.EqualError(t, err, "CA Cert for SSL id `CERT_NAME` should not have a role name")
 	})
 
-	t.Run("Role name not allowed on CA keys", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCACertificate,
-				ValueType: model.ValueTypePrivateKey,
-				RoleName:  "role name",
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "CA Cert or key for SSL id `cert-id` should not have a role name")
-	})
-
-	t.Run("Role name not allowed on keys", func(t *testing.T) {
-		t.Parallel()
-
-		certInfo := make(map[string]CertInfo)
-
-		configVar := &model.ConfigurationVariable{
-			Name:   "CERT_NAME",
-			Secret: true,
-			Generator: &model.ConfigurationVariableGenerator{
-				Type:      model.GeneratorTypeCertificate,
-				ValueType: model.ValueTypePrivateKey,
-				RoleName:  "role name",
-				ID:        certID,
-			},
-		}
-		err := RecordCertInfo(certInfo, configVar)
-
-		assert.EqualError(t, err, "Private key for SSL id `cert-id` should not have a role name")
-	})
 }
 
 func TestGenerateCerts(t *testing.T) {


### PR DESCRIPTION
* compatible with BOSH deployment manifests
* removed `Generator`
* SSL private keys and SSH fingerprints no longer have a separate entry,
* all options are now below `options`
* containerization specific variables are also below options
* variables have a type instead of a `Generator`
* certificate generation supports multiple CAs
* in contrast to BOSH empty type is supported for role manifest
* expand template now support common name in addition to alternative
names
* `subject_names` is now `alternative_names`


https://www.pivotaltracker.com/story/show/160013630