### PR TITLE
Fix dependent variable names for SSL and SSH secrets

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -22,10 +22,10 @@ const (
 )
 
 // KeySuffix is appended to the name of certificate variables private key secret
-const KeySuffix = ".key"
+const KeySuffix = "_KEY"
 
 // FingerprintSuffix is appended to the name of SSH variables fingerprint secret
-const FingerprintSuffix = ".fingerprint"
+const FingerprintSuffix = "_FINGERPRINT"
 
 // Manifest is the top level of the role manifest file
 // Variables contains information about how to configure the

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -26,7 +26,7 @@ func TestRecordKeyInfo(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.Equal(t, "foo.fingerprint", keys["foo"].Fingerprint)
+		assert.Equal(t, "foo_FINGERPRINT", keys["foo"].Fingerprint)
 		assert.Equal(t, "foo", keys["foo"].PrivateKey)
 	})
 }

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -47,7 +47,7 @@ func RecordCertInfo(certInfo map[string]CertInfo, configVar *model.VariableDefin
 
 	// Previously key and ID had the same Generator.ID, now they're not separate entries
 	info.CertificateName = util.ConvertNameToKey(configVar.Name)
-	info.PrivateKeyName = util.ConvertNameToKey(configVar.Name) + model.KeySuffix
+	info.PrivateKeyName = util.ConvertNameToKey(configVar.Name + model.KeySuffix)
 
 	info.IsAuthority = params.IsCA
 

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -48,7 +48,7 @@ func TestRecordCertInfo(t *testing.T) {
 		err := RecordCertInfo(certInfo, configVar)
 
 		require.NoError(t, err)
-		assert.Equal(t, "cert-id.key", certInfo[certID].PrivateKeyName)
+		assert.Equal(t, "cert-id-key", certInfo[certID].PrivateKeyName)
 	})
 
 	t.Run("Private key and cert should be in the same mapped value", func(t *testing.T) {
@@ -67,7 +67,7 @@ func TestRecordCertInfo(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "cert-id", certInfo[certID].CertificateName)
-		assert.Equal(t, "cert-id.key", certInfo[certID].PrivateKeyName)
+		assert.Equal(t, "cert-id-key", certInfo[certID].PrivateKeyName)
 	})
 
 	t.Run("SubjectNames are added to certInfo", func(t *testing.T) {


### PR DESCRIPTION
With BOSH a variable of type 'certificate' generates both, certificate and private key. We store the key with a special suffix and call it a 'dependent' variable.
The role manifest will have dummy entries for the dependent variables, to make helm template rendering work.

Same for SSH fingerprints.

https://www.pivotaltracker.com/story/show/160310581