### PR TITLE
Fail gracefully when generator setup is stale

### DIFF
--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -131,6 +131,13 @@ func createCA(certInfo map[string]CertInfo, secrets *v1.Secret, id string, expir
 		return fmt.Errorf("Cannot create CA: %s", err)
 	}
 
+	if len(info.PrivateKeyName) == 0 {
+		return fmt.Errorf("Cannot create CA for %s, if key name is empty", id)
+	}
+	if len(info.CertificateName) == 0 {
+		return fmt.Errorf("Cannot create CA for %s, if certificate name is empty", id)
+	}
+
 	secrets.Data[info.PrivateKeyName] = info.PrivateKey
 	secrets.Data[info.CertificateName] = info.Certificate
 

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -274,6 +274,21 @@ func TestCreateCA(t *testing.T) {
 		assert.NotEqual(t, secrets.Data[certInfo[certID].PrivateKeyName], []byte{})
 		assert.NotEqual(t, secrets.Data[certInfo[certID].CertificateName], []byte{})
 	})
+
+	t.Run("createCA should error when PrivateKeyName field is empty", func(t *testing.T) {
+		t.Parallel()
+
+		certInfo := make(map[string]CertInfo)
+		certInfo[certID] = CertInfo{
+			PrivateKeyName:  "",
+			CertificateName: "certificate-name",
+		}
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		err := createCA(certInfo, secrets, certID, 365)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot create CA for")
+	})
 }
 
 func TestAddHost(t *testing.T) {
@@ -306,6 +321,10 @@ func TestCreateCert(t *testing.T) {
 
 	// Initialize a default CA for later use
 	defaultCertInfo := make(map[string]CertInfo)
+
+	// Make sure PrivateKeyName & CertificateName are populated when calling createCA()
+	defaultCertInfo[defaultCA] = CertInfo{PrivateKeyName: "private-key", CertificateName: "certificate-name"}
+
 	secrets := &v1.Secret{Data: map[string][]byte{}}
 	createCA(defaultCertInfo, secrets, defaultCA, 365)
 


### PR DESCRIPTION
When building CACertificate secrets, make sure both cert/key pair are using the
generator key. When calling createCA() ensure that:
- PrivateKeyName and CertificateName fields are not empty.
- Test case to cover the use case when one of the fields is empty.
- Ensure all tests under TestCreateCert() will invoke createCA with populated
  PrivateKeyName and CertificateName fields.

Note:
This can happens when in the roles.yaml, one of the key/cert pair
does not contain the generator tag.