### PR TITLE
Add support for kube cert signing requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,12 @@ import (
 	"github.com/SUSE/scf-secret-generator/secrets"
 )
 
+var autoApproval = flag.Bool(
+	"autoApproval",
+	false,
+	"Attempt auto-approval of kube certificate signing requests",
+)
+
 var certExpiration = flag.Int(
 	"certExpiration",
 	30*365+7, // just over 30 years
@@ -87,6 +93,7 @@ func main() {
 	}
 
 	sg := secrets.SecretGenerator{
+		AutoApproval:      *autoApproval,
 		CertExpiration:    *certExpiration,
 		ClusterDomain:     *clusterDomain,
 		Domain:            *domain,

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ type envSettings map[string]string
 var templateEnv = make(envSettings)
 
 func (env *envSettings) String() string {
-	return ""
+	return "<envSettings>"
 }
 
 func (env *envSettings) Set(value string) error {

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -69,6 +69,7 @@ type CVOptions struct {
 type CertParams struct {
 	AlternativeNames []string `yaml:"alternative_names" json:"subject_names,omitempty"`
 	IsCA             bool     `yaml:"is_ca"`
+	AppendKubeCA     bool     `yaml:"append_kube_ca"`
 	CAName           string   `yaml:"ca"`
 	ExtKeyUsage      []string `yaml:"extended_key_usage"`
 }

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -74,7 +74,9 @@ type CertParams struct {
 	ExtKeyUsage      []string `yaml:"extended_key_usage"`
 }
 
-// GetManifest loads a manifest from file or string
+// GetManifest loads a manifest from file or string and expands all Go templates
+// under the `variables` key. The `env` parameter provides additional variables
+// that can be referenced from these templates.
 func GetManifest(r io.Reader, env map[string]string) (Manifest, error) {
 	var manifest Manifest
 
@@ -93,6 +95,9 @@ func GetManifest(r io.Reader, env map[string]string) (Manifest, error) {
 		return manifest, errors.New("'variables' section not found in manifest")
 	}
 
+	// Expand all Golang templates in the `variables` section of the manifest,
+	// using the settings in `env` as configuration variables. Changes are made
+	// in-place, so the actual return value is discarded.
 	_, err = expandTemplates(raw["variables"], env)
 	if err != nil {
 		return manifest, err

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -1,9 +1,14 @@
 package model
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"reflect"
+	"strings"
+	"text/template"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -60,20 +65,8 @@ type CVOptions struct {
 	RoleName      string   `json:"role_name,omitempty" yaml:"role_name,omitempty"`
 }
 
-// Internal structure for extracting our CVOptions into a struct
-type internalConfigurationVariable struct {
-	CVOptions CVOptions `yaml:"options"`
-}
-
-// Since we want all keys below options: but still need access to a number of fissile special
-// options.
-type internalVariableDefinitions struct {
-	Variables []*internalConfigurationVariable `yaml:"variables"`
-}
-
 // CertParams was copied from config-server/types/certificate_generator.go for on the fly parsing of certificate options
 type CertParams struct {
-	CommonName       string   `yaml:"common_name"`
 	AlternativeNames []string `yaml:"alternative_names" json:"subject_names,omitempty"`
 	IsCA             bool     `yaml:"is_ca"`
 	CAName           string   `yaml:"ca"`
@@ -81,7 +74,7 @@ type CertParams struct {
 }
 
 // GetManifest loads a manifest from file or string
-func GetManifest(r io.Reader) (Manifest, error) {
+func GetManifest(r io.Reader, env map[string]string) (Manifest, error) {
 	var manifest Manifest
 
 	data, err := ioutil.ReadAll(r)
@@ -89,15 +82,32 @@ func GetManifest(r io.Reader) (Manifest, error) {
 		return manifest, err
 	}
 
+	// Read raw (no schema) manifest so we can expand templates in the variables section.
+	var raw map[string]interface{}
+	err = yaml.Unmarshal(data, &raw)
+	if err != nil {
+		return manifest, err
+	}
+	if raw["variables"] == nil {
+		return manifest, errors.New("'variables' section not found in manifest")
+	}
+
+	_, err = expandTemplates(raw["variables"], env)
+	if err != nil {
+		return manifest, err
+	}
+
+	// Turn manifest with expanded templates back into a string and unmarshal using manifest schema.
+	data, err = yaml.Marshal(raw)
+	if err != nil {
+		return manifest, err
+	}
 	err = yaml.Unmarshal(data, &manifest)
 	if err != nil {
 		return manifest, err
 	}
 
-	if err == nil && manifest.Variables == nil {
-		return manifest, errors.New("'Variables section' not found in manifest")
-	}
-
+	// Validate that we have no duplicate variable names.
 	seen := make(map[string]bool)
 	for _, v := range manifest.Variables {
 		if seen[v.Name] {
@@ -106,26 +116,88 @@ func GetManifest(r io.Reader) (Manifest, error) {
 		seen[v.Name] = true
 	}
 
-	// clean up, since we parse these into CVOptions
-	for _, v := range manifest.Variables {
-		delete(v.Options, "previous_names")
-		delete(v.Options, "generator")
-		delete(v.Options, "secret")
-		delete(v.Options, "immutable")
-		delete(v.Options, "role_name")
-	}
-
-	var definitions internalVariableDefinitions
-	err = yaml.Unmarshal(data, &definitions)
-	if err != nil {
-		return manifest, err
-	}
-
-	for i, v := range definitions.Variables {
-		manifest.Variables[i].CVOptions = v.CVOptions
+	// Parse Options using the CVOptions schema.
+	for i, v := range manifest.Variables {
+		str, err := yaml.Marshal(v.Options)
+		if err != nil {
+			return manifest, err
+		}
+		err = yaml.Unmarshal(str, &manifest.Variables[i].CVOptions)
+		if err != nil {
+			return manifest, err
+		}
 	}
 
 	return manifest, err
+}
+
+// Walk the tree and expand templates in-place in all string nodes.
+func expandTemplates(node interface{}, env map[string]string) (interface{}, error) {
+	if node == nil {
+		// Must return `node` here to get a "typed nil".
+		return node, nil
+	}
+
+	switch reflect.TypeOf(node).Kind() {
+	case reflect.Map:
+		valueOf := reflect.ValueOf(node)
+		for _, key := range valueOf.MapKeys() {
+			elem := valueOf.MapIndex(key).Interface()
+			if elem != nil {
+				newNode, err := expandTemplates(elem, env)
+				if err != nil {
+					return nil, err
+				}
+				if newNode == nil {
+					valueOf.SetMapIndex(key, reflect.Zero(valueOf.MapIndex(key).Type()))
+				} else {
+					valueOf.SetMapIndex(key, reflect.ValueOf(newNode))
+				}
+			}
+		}
+		return valueOf.Interface(), nil
+
+	case reflect.Slice:
+		valueOf := reflect.ValueOf(node)
+		for i := 0; i < valueOf.Len(); i++ {
+			elemValue := valueOf.Index(i)
+			newNode, err := expandTemplates(elemValue.Interface(), env)
+			if err != nil {
+				return nil, err
+			}
+			if newNode == nil {
+				elemValue.Set(reflect.Zero(elemValue.Type()))
+			} else {
+				elemValue.Set(reflect.ValueOf(newNode))
+			}
+		}
+		return valueOf.Interface(), nil
+
+	case reflect.String:
+		str := node.(string)
+		if strings.Contains(str, "{{") {
+			t, err := template.New("").Parse(str)
+			if err != nil {
+				return nil, fmt.Errorf("Can't parse template in `%s`: %v", str, err)
+			}
+			buf := &bytes.Buffer{}
+			err = t.Execute(buf, env)
+			if err != nil {
+				return nil, err
+			}
+			// If the string is a template expression from start to end, then run the
+			// result through YAML parsing again to allow the result to change type
+			// from string to boolean/number/null.
+			if strings.HasPrefix(str, "{{") && strings.HasSuffix(str, "}}") {
+				var data interface{}
+				err = yaml.Unmarshal(buf.Bytes(), &data)
+				return data, err
+			}
+			return buf.String(), nil
+		}
+	}
+
+	return node, nil
 }
 
 // OptionsAsCertificateParams returns the variables options as a struct of certificate parameters
@@ -142,20 +214,4 @@ func (cv *VariableDefinition) OptionsAsCertificateParams() (CertParams, error) {
 	}
 
 	return params, nil
-}
-
-// SetOptions updates the variables options from the certificate parameters
-func (cv *VariableDefinition) SetOptions(params interface{}) error {
-	str, err := yaml.Marshal(params)
-	if err != nil {
-		return err
-	}
-
-	options := VariableOptions{}
-	err = yaml.Unmarshal(str, &options)
-	if err != nil {
-		return err
-	}
-	cv.Options = options
-	return nil
 }

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -10,17 +10,17 @@ import (
 func TestManifestFileIsInvalid(t *testing.T) {
 	t.Parallel()
 
-	_, err := GetManifest(strings.NewReader("123123 123123"))
+	_, err := GetManifest(strings.NewReader("123123 123123"), nil)
 
-	assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `123123 ...` into model.Manifest")
+	assert.EqualError(t, err, "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `123123 ...` into map[string]interface {}")
 }
 
 func TestManifestConfigurationSectionNotFound(t *testing.T) {
 	t.Parallel()
 
-	_, err := GetManifest(strings.NewReader("roles: []"))
+	_, err := GetManifest(strings.NewReader("roles: []"), nil)
 
-	assert.EqualError(t, err, "'Variables section' not found in manifest")
+	assert.EqualError(t, err, "'variables' section not found in manifest")
 }
 
 var exampleManifest = `
@@ -59,7 +59,7 @@ variables:
 func TestManifestConfigurationHasOptions(t *testing.T) {
 	t.Parallel()
 
-	m, err := GetManifest(strings.NewReader(exampleManifest))
+	m, err := GetManifest(strings.NewReader(exampleManifest), nil)
 	assert.NoError(t, err)
 
 	for _, v := range m.Variables {
@@ -75,7 +75,6 @@ func TestManifestConfigurationHasOptions(t *testing.T) {
 	assert.Equal(t, VariableTypeCertificate, v.Type)
 	assert.Equal(t, "default_ca", v.Options["ca"])
 	assert.Equal(t, true, v.CVOptions.Secret)
-	assert.Nil(t, v.Options["secret"])
 
 	v = m.Variables[2]
 	assert.Equal(t, "c", v.Name)
@@ -90,6 +89,76 @@ func TestManifestConfigurationHasOptions(t *testing.T) {
 func TestManifestUniqueNames(t *testing.T) {
 	t.Parallel()
 
-	_, err := GetManifest(strings.NewReader(duplicateNameManifest))
+	_, err := GetManifest(strings.NewReader(duplicateNameManifest), nil)
 	assert.EqualError(t, err, "Duplicate variable name found in manifest")
+}
+
+var templateManifest = `
+instance_groups: []
+variables:
+- name: SSL_CERT
+  options:
+    secret: true
+    ca: INTERNAL_CA_CERT
+    role_name: "foo.{{.KUBERNETES_NAMESPACE}}"
+    alternative_names:
+    - "*.{{.DOMAIN}}"
+    - "foo.{{.KUBERNETES_NAMESPACE}}"
+    - "svc.{{.KUBERNETES_CLUSTER_DOMAIN}}"
+    # The following entries only exist to prove that the template expander will leave
+    # existing boolean/nil values as-is, and can replace string values with other types.
+    test:
+      array: [false, null, "{{.IT_IS_TRUE}}", "{{.NOTHING}}"]
+      none: ~
+      nothing: "{{.NOTHING}}"
+      right: "{{.IT_IS_TRUE}}"
+      wrong: false
+  type: certificate
+`
+
+func TestExpandTemplates(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"DOMAIN":                    "domain",
+		"KUBERNETES_CLUSTER_DOMAIN": "cluster.domain",
+		"KUBERNETES_NAMESPACE":      "namespace",
+		"IT_IS_TRUE":                "true",
+		"NOTHING":                   "~",
+	}
+	m, err := GetManifest(strings.NewReader(templateManifest), env)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo.namespace", m.Variables[0].CVOptions.RoleName)
+
+	params, err := m.Variables[0].OptionsAsCertificateParams()
+	assert.NoError(t, err)
+
+	names := params.AlternativeNames
+	assert.Len(t, names, 3)
+	assert.Equal(t, "*.domain", names[0])
+	assert.Equal(t, "foo.namespace", names[1])
+	assert.Equal(t, "svc.cluster.domain", names[2])
+
+	test := m.Variables[0].Options["test"].(map[interface{}]interface{})
+	array := test["array"].([]interface{})
+	assert.False(t, array[0].(bool))
+	assert.Nil(t, array[1])
+	assert.True(t, array[2].(bool))
+	assert.Nil(t, array[3])
+
+	value, ok := test["none"]
+	assert.True(t, ok)
+	assert.Nil(t, value)
+
+	value, ok = test["nothing"]
+	assert.True(t, ok)
+	assert.Nil(t, value)
+
+	value, ok = test["right"]
+	assert.True(t, ok)
+	assert.True(t, value.(bool))
+
+	value, ok = test["wrong"]
+	assert.True(t, ok)
+	assert.False(t, value.(bool))
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"io"
 	"log"
 	"strings"
@@ -48,6 +47,7 @@ type SecretGenerator struct {
 	SecretsConfigMapName string
 	SecretsGeneration    string
 	SecretsName          string
+	TemplateEnv          map[string]string
 }
 
 // Generate will fetch the current secrets, generate any missing values, and writes the new secrets
@@ -80,11 +80,8 @@ func (sg *SecretGenerator) Generate(manifestReader io.Reader) error {
 	if err != nil {
 		return err
 	}
-	manifest, err := model.GetManifest(manifestReader)
-	if err != nil {
-		return err
-	}
-	err = sg.expandTemplates(manifest)
+
+	manifest, err := model.GetManifest(manifestReader, sg.TemplateEnv)
 	if err != nil {
 		return err
 	}
@@ -232,57 +229,6 @@ func (sg *SecretGenerator) getSecret(s secretInterface, configMap *v1.ConfigMap)
 		newSecret.Data = currentSecret.Data
 	}
 	return newSecret, nil
-}
-
-func (sg *SecretGenerator) expandTemplates(manifest model.Manifest) error {
-	for _, configVar := range manifest.Variables {
-		if configVar.Type != model.VariableTypeCertificate {
-			continue
-		}
-
-		params, err := configVar.OptionsAsCertificateParams()
-		if err != nil {
-			return fmt.Errorf("Can't parse certificate config variable `%s`: %s", configVar.Name, err)
-		}
-
-		buf, err := sg.expandDomainName(configVar.Name, params.CommonName)
-		if err != nil {
-			return err
-		}
-		params.CommonName = buf
-
-		for index, name := range params.AlternativeNames {
-			buf, err := sg.expandDomainName(configVar.Name, name)
-			if err != nil {
-				return err
-			}
-			params.AlternativeNames[index] = buf
-		}
-
-		err = configVar.SetOptions(params)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (sg *SecretGenerator) expandDomainName(configVarName string, name string) (string, error) {
-	mapping := map[string]string{
-		"DOMAIN":                    sg.Domain,
-		"KUBERNETES_CLUSTER_DOMAIN": sg.ClusterDomain,
-		"KUBERNETES_NAMESPACE":      sg.Namespace,
-	}
-	t, err := template.New("").Parse(name)
-	if err != nil {
-		return "", fmt.Errorf("Can't parse subject name `%s` for config variable `%s`: %s", name, configVarName, err)
-	}
-	buf := &bytes.Buffer{}
-	err = t.Execute(buf, mapping)
-	if err != nil {
-		return "", err
-	}
-	return buf.String(), nil
 }
 
 // generateSecret will generate all secrets defined in the manifest that don't already exist

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -142,7 +142,7 @@ func (sg *SecretGenerator) getSecretInterface() (secretInterface, error) {
 	return clientset.CoreV1().Secrets(sg.Namespace), nil
 }
 
-// getSecretInterface returns a secrets interface for the namespace
+// getCertificateSigningRequestInterface returns a csr interface
 func (sg *SecretGenerator) getCertificateSigningRequestInterface() (util.CertificateSigningRequestInterface, error) {
 	clientset, err := kubeClientset()
 	if err != nil {

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -498,7 +498,7 @@ func TestGeneratePasswordSecret(t *testing.T) {
 
 		assert.Equal(t, []byte("obsolete"), secrets.Data["non-generated"])
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.Empty(t, secrets.Data["non-generated"])
@@ -532,7 +532,7 @@ func TestGeneratePasswordSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["dirty"])
 		assert.Empty(t, secrets.Data["dirty"+generatorSuffix])
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["dirty"])
@@ -568,7 +568,7 @@ func TestGeneratePasswordSecret(t *testing.T) {
 		generatorInput := secrets.Data["clean"+generatorSuffix]
 		assert.NotEmpty(t, generatorInput)
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.Equal(t, []byte("clean"), secrets.Data["clean"])
@@ -604,7 +604,7 @@ func TestGeneratePasswordSecret(t *testing.T) {
 		generatorInput := secrets.Data["clean"+generatorSuffix]
 
 		sg.SecretsGeneration = "2"
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["clean"])
@@ -642,7 +642,7 @@ func TestGeneratePasswordSecret(t *testing.T) {
 		setSecret(secrets, manifest.Variables[0], "clean")
 
 		sg.SecretsGeneration = "2"
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.Equal(t, []byte("clean"), secrets.Data["clean"])
@@ -681,7 +681,7 @@ func TestGenerateSSHSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["ssh-key"+model.FingerprintSuffix])
 		assert.Empty(t, secrets.Data["ssh-key"+generatorSuffix])
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ssh-key"])
@@ -715,7 +715,7 @@ func TestGenerateSSHSecret(t *testing.T) {
 		setSecret(secrets, manifest.Variables[0], "key")
 		setSecretFingerprint(secrets, manifest.Variables[0], "fingerprint")
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.Equal(t, []byte("key"), secrets.Data["ssh-key"])
@@ -758,7 +758,7 @@ func TestGenerateSSLSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["ca-cert"+generatorSuffix])
 		assert.Empty(t, secrets.Data["ca-cert-key"])
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ca-cert"])
@@ -797,7 +797,7 @@ func TestGenerateSSLSecret(t *testing.T) {
 		setSecret(secrets, manifest.Variables[0], "cert")
 		setSecretKey(secrets, manifest.Variables[0], "key")
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.Equal(t, []byte("cert"), secrets.Data["ca-cert"])
@@ -846,7 +846,7 @@ func TestGenerateSSLSecret(t *testing.T) {
 		assert.Empty(t, secrets.Data["ssl-cert"+generatorSuffix])
 		assert.Empty(t, secrets.Data["ssl-cert-key"])
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])
@@ -891,7 +891,7 @@ func TestGenerateSSLSecret(t *testing.T) {
 		setSecret(secrets, manifest.Variables[1], "cert-data")
 		setSecretKey(secrets, manifest.Variables[1], "key-data")
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.Equal(t, []byte("cert-data"), secrets.Data["ssl-cert"])
@@ -954,7 +954,7 @@ func TestGenerateSSLSecret(t *testing.T) {
 		assert.NotEmpty(t, secrets.Data["ssl-cert"+generatorSuffix])
 		assert.NotContains(t, string(secrets.Data["ssl-cert"+generatorSuffix]), "alternative_names")
 
-		err := sg.generateSecret(manifest, secrets, configMap)
+		err := sg.generateSecret(nil, manifest, secrets, configMap)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data["ssl-cert"])

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -466,44 +466,6 @@ func TestGetSecret(t *testing.T) {
 	})
 }
 
-func TestExpandTemplates(t *testing.T) {
-	t.Parallel()
-
-	sg := testingSecretGenerator()
-
-	manifest := model.Manifest{
-		Variables: model.Variables{
-			{
-				Name: "ssl-cert",
-				Type: model.VariableTypeCertificate,
-				Options: model.VariableOptions{
-					"common_name": "foo.{{.KUBERNETES_NAMESPACE}}",
-					"alternative_names": []string{
-						"*.{{.DOMAIN}}",
-						"foo.{{.KUBERNETES_NAMESPACE}}",
-						"svc.{{.KUBERNETES_CLUSTER_DOMAIN}}"},
-				},
-				CVOptions: model.CVOptions{
-					Secret: true,
-				},
-			},
-		},
-	}
-
-	err := sg.expandTemplates(manifest)
-	assert.NoError(t, err)
-
-	params, err := manifest.Variables[0].OptionsAsCertificateParams()
-	assert.NoError(t, err)
-	assert.Equal(t, "foo.namespace", params.CommonName)
-
-	names := params.AlternativeNames
-	assert.Len(t, names, 3)
-	assert.Equal(t, "*.domain", names[0])
-	assert.Equal(t, "foo.namespace", names[1])
-	assert.Equal(t, "svc.cluster.domain", names[2])
-}
-
 func TestGeneratePasswordSecret(t *testing.T) {
 	t.Parallel()
 

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -17,17 +17,17 @@ import (
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/cloudflare/cfssl/signer/local"
 
+	certificates "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const defaultCA = "cacert"
 
 // CertInfo contains all the information required to generate an SSL cert
 type CertInfo struct {
 	PrivateKeyName  string // Name to associate with private key
 	CertificateName string // Name to associate with certificate
 	IsAuthority     bool
-	AppendKubeCA    bool
+	KubeCACertFile  string
 	CAName          string
 
 	SubjectNames []string
@@ -35,6 +35,8 @@ type CertInfo struct {
 
 	Certificate []byte
 	PrivateKey  []byte
+
+	CSRName string // Name of kube csr
 }
 
 // RecordCertInfo record cert information for later generation
@@ -52,12 +54,14 @@ func RecordCertInfo(certInfo map[string]CertInfo, configVar *model.VariableDefin
 	info.CertificateName = util.ConvertNameToKey(configVar.Name)
 	info.PrivateKeyName = util.ConvertNameToKey(configVar.Name + model.KeySuffix)
 
-	info.IsAuthority = params.IsCA
-	info.AppendKubeCA = params.AppendKubeCA
-
-	if info.AppendKubeCA && !info.IsAuthority {
+	if params.AppendKubeCA && !params.IsCA {
 		return fmt.Errorf("Can't append kube CA to regular cert id `%s`; only works for CA certs",
 			configVar.Name)
+	}
+
+	info.IsAuthority = params.IsCA
+	if params.AppendKubeCA {
+		info.KubeCACertFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	}
 
 	if len(params.CAName) > 0 {
@@ -86,7 +90,7 @@ func RecordCertInfo(certInfo map[string]CertInfo, configVar *model.VariableDefin
 }
 
 // GenerateCerts creates an SSL cert and private key
-func GenerateCerts(certInfo map[string]CertInfo, namespace, clusterDomain string, expiration int, secrets *v1.Secret) error {
+func GenerateCerts(certInfo map[string]CertInfo, csri util.CertificateSigningRequestInterface, namespace, clusterDomain string, expiration int, autoApproval bool, secrets *v1.Secret) error {
 	// generate all the CAs first because they are needed to sign the certs
 	for id, info := range certInfo {
 		if !info.IsAuthority {
@@ -125,7 +129,7 @@ func GenerateCerts(certInfo map[string]CertInfo, namespace, clusterDomain string
 			}
 			mut.Unlock()
 
-			newCert, err := createCert(certInfo, namespace, clusterDomain, secrets, id, expiration)
+			newCert, err := createCert(certInfo, csri, namespace, clusterDomain, secrets, id, expiration, autoApproval)
 			mut.Lock()
 			defer mut.Unlock()
 			if err != nil {
@@ -145,13 +149,43 @@ func GenerateCerts(certInfo map[string]CertInfo, namespace, clusterDomain string
 		}(id, info)
 	}
 	wg.Wait()
+
+	var err error
 	if len(errs) > 0 {
-		return errs[0]
+		err = errs[0]
 	}
+
 	for id, newCert := range newCerts {
+		if newCert.CSRName != "" {
+			if err == nil {
+				newCert, err = waitForKubeCSR(csri, *newCert)
+				if err != nil {
+					err = fmt.Errorf("Kube CSR failed with %s", err)
+				}
+				secrets.Data[newCert.PrivateKeyName] = newCert.PrivateKey
+				secrets.Data[newCert.CertificateName] = newCert.Certificate
+			}
+			_ = csri.Delete(newCert.CSRName, &metav1.DeleteOptions{})
+		}
+
+		// Once we hit an error we just delete all still outstanding kube csrs
+		// and then return the first error we encountered.
+		if err != nil {
+			continue
+		}
+
+		if len(newCert.PrivateKeyName) == 0 {
+			err = fmt.Errorf("Certificate %s created with empty private key name", id)
+		} else if len(newCert.PrivateKey) == 0 {
+			err = fmt.Errorf("Certificate %s created with empty private key", id)
+		} else if len(newCert.CertificateName) == 0 {
+			err = fmt.Errorf("Certificate %s created with empty certificate name", id)
+		} else if len(newCert.Certificate) == 0 {
+			err = fmt.Errorf("Certificate %s created with empty certificate", id)
+		}
 		certInfo[id] = *newCert
 	}
-	return nil
+	return err
 }
 
 func rsaKeyRequest() *csr.BasicKeyRequest {
@@ -183,10 +217,10 @@ func createCA(certInfo map[string]CertInfo, secrets *v1.Secret, id string, expir
 	secrets.Data[info.PrivateKeyName] = info.PrivateKey
 	secrets.Data[info.CertificateName] = info.Certificate
 
-	if info.AppendKubeCA {
-		glog.Printf("appending kube CA cert to CA cert %s", id)
+	if info.KubeCACertFile != "" {
+		glog.Printf("appending kube CA cert from %s to to CA cert %s", info.KubeCACertFile, id)
 
-		kubeCert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+		kubeCert, err := ioutil.ReadFile(info.KubeCACertFile)
 		if err != nil {
 			return fmt.Errorf("Cannot read kube CA cert: %s", err)
 		}
@@ -209,19 +243,9 @@ func addHost(req *csr.CertificateRequest, wildcard bool, name string) {
 // returns the new certificate, rather than modifying it in-place, in order to
 // make it possible for various certificates to be generated in parallel.  This
 // is useful as key generation can be slow.
-func createCert(certInfo map[string]CertInfo, namespace, clusterDomain string, secrets *v1.Secret, id string, expiration int) (*CertInfo, error) {
+func createCert(certInfo map[string]CertInfo, csri util.CertificateSigningRequestInterface, namespace, clusterDomain string, secrets *v1.Secret, id string, expiration int, autoApproval bool) (*CertInfo, error) {
 	var err error
 	info := certInfo[id]
-
-	caName := defaultCA
-	if info.CAName != "" {
-		caName = info.CAName
-	}
-
-	caInfo := certInfo[caName]
-	if len(caInfo.PrivateKey) == 0 || len(caInfo.Certificate) == 0 {
-		return nil, fmt.Errorf("CA %s not found", caName)
-	}
 
 	req := &csr.CertificateRequest{KeyRequest: rsaKeyRequest()}
 
@@ -252,7 +276,20 @@ func createCert(certInfo map[string]CertInfo, namespace, clusterDomain string, s
 	g := &csr.Generator{Validator: genkey.Validator}
 	signingReq, info.PrivateKey, err = g.ProcessRequest(req)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot generate cert: %s", err)
+		return nil, fmt.Errorf("Cannot generate csr: %s", err)
+	}
+
+	if info.CAName == "" {
+		info, err := createKubeCSR(csri, signingReq, info, namespace, id, autoApproval)
+		if err == nil && autoApproval {
+			approveKubeCSR(csri, info.CSRName)
+		}
+		return info, err
+	}
+
+	caInfo := certInfo[info.CAName]
+	if len(caInfo.PrivateKey) == 0 || len(caInfo.Certificate) == 0 {
+		return nil, fmt.Errorf("CA %s not found", info.CAName)
 	}
 
 	caCert, err := helpers.ParseCertificatePEM(caInfo.Certificate)
@@ -284,18 +321,80 @@ func createCert(certInfo map[string]CertInfo, namespace, clusterDomain string, s
 		return nil, fmt.Errorf("Failed to sign cert: %s", err)
 	}
 
-	if len(info.PrivateKeyName) == 0 {
-		return nil, fmt.Errorf("Certificate %s created with empty private key name", id)
+	return &info, nil
+}
+func createKubeCSR(csri util.CertificateSigningRequestInterface, request []byte, info CertInfo, namespace, id string, autoApproval bool) (*CertInfo, error) {
+	csr := &certificates.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: util.ConvertNameToKey(fmt.Sprintf("%s-%s", namespace, id)),
+		},
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request: request,
+			Usages: []certificates.KeyUsage{
+				certificates.UsageClientAuth,
+				certificates.UsageServerAuth,
+			},
+			// expiration is determined by apiserver and cannot be configured
+		},
 	}
-	if len(info.PrivateKey) == 0 {
-		return nil, fmt.Errorf("Certificate %s created with empty private key", id)
+	glog.Printf("create kube csr %s", csr.Name)
+	csr, err := csri.Create(csr)
+	if err == nil {
+		info.CSRName = csr.Name
 	}
-	if len(info.CertificateName) == 0 {
-		return nil, fmt.Errorf("Certificate %s created with empty certificate name", id)
-	}
-	if len(info.Certificate) == 0 {
-		return nil, fmt.Errorf("Certificate %s created with empty certificate", id)
+	return &info, err
+}
+
+func approveKubeCSR(csri util.CertificateSigningRequestInterface, csrName string) {
+	glog.Printf("attempting to auto-approve kube csr %s", csrName)
+
+	csr, err := csri.Get(csrName, metav1.GetOptions{})
+	if err != nil {
+		glog.Printf("unexpected error during get kube csr %s: %v", csrName, err)
+		return
 	}
 
+	csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
+		Type:    certificates.CertificateApproved,
+		Reason:  "Autoapproved",
+		Message: "This csr was approved automatically by scf-secrets-generator",
+	})
+	csr, err = csri.UpdateApproval(csr)
+	if err != nil {
+		glog.Printf("cannot auto-approve kube csr %s: %v\nwaiting for manual approval", csr.Name, err)
+	} else {
+		glog.Printf("kube csr %s has been auto-approved", csr.Name)
+	}
+}
+
+func waitForKubeCSR(csri util.CertificateSigningRequestInterface, info CertInfo) (*CertInfo, error) {
+	name := info.CSRName
+	var csr *certificates.CertificateSigningRequest
+	var err error
+	for retry := 0; ; retry++ {
+		csr, err = csri.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return &info, fmt.Errorf("fetching kube csr %s returned error %s", name, err)
+		}
+		if len(csr.Status.Conditions) > 0 && len(csr.Status.Conditions[0].Type) > 0 {
+			break
+		}
+		switch {
+		case retry == 0:
+			glog.Printf("waiting for kube csr %s to be approved", name)
+			time.Sleep(2 * time.Second)
+		case retry < 10:
+			time.Sleep(5 * time.Second)
+		default:
+			time.Sleep(20 * time.Second)
+		}
+	}
+	cond := csr.Status.Conditions[0]
+	if cond.Type != certificates.CertificateApproved {
+		return &info, fmt.Errorf("kube csr %s failed, condition is %s, reason: %s, message: %s",
+			name, cond.Type, cond.Reason, cond.Message)
+	}
+	info.Certificate = csr.Status.Certificate
 	return &info, nil
+
 }

--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -338,7 +338,11 @@ func createKubeCSR(csri util.CertificateSigningRequestInterface, request []byte,
 		},
 	}
 	glog.Printf("create kube csr %s", csr.Name)
-	csr, err := csri.Create(csr)
+	err := csri.Delete(csr.Name, &metav1.DeleteOptions{})
+	if err == nil {
+		glog.Printf("kube csr %s already existed and has been deleted", csr.Name)
+	}
+	csr, err = csri.Create(csr)
 	if err == nil {
 		info.CSRName = csr.Name
 	}

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -56,6 +56,9 @@ func (m *MockCertificateSigningRequestInterface) Get(name string, options metav1
 	m.getCount++
 	if (name == string(certificates.CertificateApproved) || name == string(certificates.CertificateDenied)) && m.getCount > 1 {
 		csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
+			Type: certificates.RequestConditionType("bogus"),
+		})
+		csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
 			Type:    certificates.RequestConditionType(name),
 			Reason:  "because, why not?",
 			Message: "Seriously!",
@@ -724,7 +727,7 @@ func TestWaitForKubeCSR(t *testing.T) {
 
 		csri.AssertCalled(t, "Get", info.CSRName, metav1.GetOptions{})
 
-		assert.EqualError(t, err, "kube csr Denied failed, condition is Denied, reason: because, why not?, message: Seriously!")
+		assert.EqualError(t, err, "kube csr Denied denied, reason: because, why not?, message: Seriously!")
 	})
 
 	t.Run("waitForKubeCSR returns an error if the CSR cannot be found", func(t *testing.T) {

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -4,17 +4,73 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/SUSE/scf-secret-generator/model"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	certificates "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const defaultCA = "cacert"
 const certID = "cert-id"
+
+type MockBase struct {
+	mock.Mock
+}
+
+type MockCertificateSigningRequestInterface struct {
+	MockBase
+	getCount int
+}
+
+func (m *MockCertificateSigningRequestInterface) Create(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error) {
+	m.Called(csr)
+	return csr, nil
+}
+
+func (m *MockCertificateSigningRequestInterface) Delete(name string, options *metav1.DeleteOptions) error {
+	m.Called(name, options)
+	return nil
+}
+
+func (m *MockCertificateSigningRequestInterface) Get(name string, options metav1.GetOptions) (*certificates.CertificateSigningRequest, error) {
+	m.Called(name, options)
+	csr := &certificates.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request: []byte("some-request"),
+			Usages:  []certificates.KeyUsage{certificates.UsageClientAuth, certificates.UsageServerAuth},
+		},
+	}
+	if name == "Failed" {
+		return csr, errors.New("Something went wrong")
+	}
+
+	m.getCount++
+	if (name == string(certificates.CertificateApproved) || name == string(certificates.CertificateDenied)) && m.getCount > 1 {
+		csr.Status.Conditions = append(csr.Status.Conditions, certificates.CertificateSigningRequestCondition{
+			Type:    certificates.RequestConditionType(name),
+			Reason:  "because, why not?",
+			Message: "Seriously!",
+		})
+		if name == string(certificates.CertificateApproved) {
+			csr.Status.Certificate = []byte("shiny")
+		}
+	}
+	return csr, nil
+}
+
+func (m *MockCertificateSigningRequestInterface) UpdateApproval(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error) {
+	m.Called(csr)
+	return csr, nil
+}
 
 func TestRecordCertInfo(t *testing.T) {
 	t.Parallel()
@@ -148,6 +204,28 @@ func TestRecordCertInfo(t *testing.T) {
 		assert.EqualError(t, err, "CA Cert for SSL id `CERT_NAME` should not have a role name")
 	})
 
+	t.Run("append_kube_ca sets path to kube CA cert", func(t *testing.T) {
+		t.Parallel()
+
+		certInfo := make(map[string]CertInfo)
+
+		configVar := &model.VariableDefinition{
+			Name: certID,
+			Type: model.VariableTypeCertificate,
+			Options: model.VariableOptions{
+				"is_ca":          true,
+				"append_kube_ca": true,
+			},
+			CVOptions: model.CVOptions{
+				Secret: true,
+			},
+		}
+		err := RecordCertInfo(certInfo, configVar)
+
+		require.NoError(t, err)
+		assert.Equal(t, "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", certInfo[certID].KubeCACertFile)
+	})
+
 }
 
 func TestGenerateCerts(t *testing.T) {
@@ -165,10 +243,11 @@ func TestGenerateCerts(t *testing.T) {
 			// here as bait, in case GenerateCerts() decides to call createCert instead of createCA
 			SubjectNames: []string{"subject-names"},
 			RoleName:     "dummy-role",
+			CAName:       defaultCA,
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		err := GenerateCerts(certInfo, "namespace", "cluster.domain", 700, secrets)
+		err := GenerateCerts(certInfo, nil, "namespace", "cluster.domain", 700, false, secrets)
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data[certInfo[defaultCA].PrivateKeyName])
@@ -194,10 +273,11 @@ func TestGenerateCerts(t *testing.T) {
 			IsAuthority:     false,
 			PrivateKeyName:  "ca-key",
 			CertificateName: "ca-name",
+			CAName:          defaultCA,
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		err := GenerateCerts(certInfo, "namespace", "cluster.domain", 365, secrets)
+		err := GenerateCerts(certInfo, nil, "namespace", "cluster.domain", 365, false, secrets)
 
 		assert.EqualError(t, err, "CA "+defaultCA+" not found")
 		assert.Empty(t, secrets.Data[certInfo[certID].PrivateKeyName])
@@ -209,8 +289,9 @@ func TestGenerateCerts(t *testing.T) {
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
 			RoleName:        "dummy-role",
+			CAName:          defaultCA,
 		}
-		err = GenerateCerts(certInfo, "namespace", "cluster.domain", 30, secrets)
+		err = GenerateCerts(certInfo, nil, "namespace", "cluster.domain", 30, false, secrets)
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, secrets.Data[certInfo[certID].PrivateKeyName])
@@ -240,9 +321,10 @@ func TestGenerateCerts(t *testing.T) {
 		certInfo[certID] = CertInfo{
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
+			CAName:          defaultCA,
 		}
 
-		err := GenerateCerts(certInfo, "namespace", "cluster.domain", 365, secrets)
+		err := GenerateCerts(certInfo, nil, "namespace", "cluster.domain", 365, false, secrets)
 
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("private-key-data"), secrets.Data["private-key"])
@@ -259,9 +341,10 @@ func TestGenerateCerts(t *testing.T) {
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
+			CAName:          defaultCA,
 		}
 
-		err := GenerateCerts(certInfo, "namespace", "cluster.domain", 365, secrets)
+		err := GenerateCerts(certInfo, nil, "namespace", "cluster.domain", 365, false, secrets)
 		require.NoError(t, err, "Error creating certificate")
 
 		assert.NotEmpty(t, secrets.Data[certInfo[certID].PrivateKeyName])
@@ -315,6 +398,27 @@ func TestCreateCA(t *testing.T) {
 
 		assert.NotEqual(t, secrets.Data[certInfo[certID].PrivateKeyName], []byte{})
 		assert.NotEqual(t, secrets.Data[certInfo[certID].CertificateName], []byte{})
+		assert.Regexp(t, "(?s)\\A-----BEGIN CERTIFICATE-----\\n.*\\n-----END CERTIFICATE-----\\n\\z",
+			string(secrets.Data[certInfo[certID].CertificateName]))
+	})
+
+	t.Run("createCA appends kube CA cert when requested", func(t *testing.T) {
+		t.Parallel()
+
+		certInfo := make(map[string]CertInfo)
+		certInfo[certID] = CertInfo{
+			PrivateKeyName:  "private-key",
+			CertificateName: "certificate-name",
+			KubeCACertFile:  "testdata/kubeca.crt",
+		}
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		createCA(certInfo, secrets, certID, 365)
+
+		assert.NotEqual(t, secrets.Data[certInfo[certID].PrivateKeyName], []byte{})
+		assert.NotEqual(t, secrets.Data[certInfo[certID].CertificateName], []byte{})
+		assert.Contains(t, string(secrets.Data[certInfo[certID].CertificateName]),
+			"-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----")
 	})
 }
 
@@ -358,9 +462,15 @@ func TestCreateCert(t *testing.T) {
 		certInfo[defaultCA] = CertInfo{
 			Certificate: defaultCertInfo[defaultCA].Certificate,
 		}
+		certInfo[certID] = CertInfo{
+			PrivateKeyName:  "private-key",
+			CertificateName: "certificate-name",
+			SubjectNames:    []string{"subject-names"},
+			CAName:          defaultCA,
+		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		newCert, err := createCert(certInfo, "namespace", "cluster.domain", secrets, certID, 365)
+		newCert, err := createCert(certInfo, nil, "namespace", "cluster.domain", secrets, certID, 365, false)
 
 		assert.EqualError(t, err, "CA "+defaultCA+" not found")
 		assert.Nil(t, newCert, "New cert generated even with error")
@@ -373,9 +483,15 @@ func TestCreateCert(t *testing.T) {
 		certInfo[defaultCA] = CertInfo{
 			PrivateKey: defaultCertInfo[defaultCA].PrivateKey,
 		}
+		certInfo[certID] = CertInfo{
+			PrivateKeyName:  "private-key",
+			CertificateName: "certificate-name",
+			SubjectNames:    []string{"subject-names"},
+			CAName:          defaultCA,
+		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		newCert, err := createCert(certInfo, "namespace", "cluster.domain", secrets, certID, 365)
+		newCert, err := createCert(certInfo, nil, "namespace", "cluster.domain", secrets, certID, 365, false)
 
 		assert.EqualError(t, err, "CA "+defaultCA+" not found")
 		assert.Nil(t, newCert, "New cert generated even with error")
@@ -394,10 +510,11 @@ func TestCreateCert(t *testing.T) {
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
+			CAName:          defaultCA,
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		newCert, err := createCert(certInfo, "namespace", "cluster.domain", secrets, certID, 365)
+		newCert, err := createCert(certInfo, nil, "namespace", "cluster.domain", secrets, certID, 365, false)
 		require.Error(t, err, "Expected CA parsing to fail")
 
 		assert.Contains(t, err.Error(), "Cannot parse CA cert")
@@ -417,10 +534,11 @@ func TestCreateCert(t *testing.T) {
 			PrivateKeyName:  "private-key",
 			CertificateName: "certificate-name",
 			SubjectNames:    []string{"subject-names"},
+			CAName:          defaultCA,
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		newCert, err := createCert(certInfo, "namespace", "cluster.domain", secrets, certID, 365)
+		newCert, err := createCert(certInfo, nil, "namespace", "cluster.domain", secrets, certID, 365, false)
 		require.Error(t, err, "Expected CA parsing to fail")
 
 		assert.Contains(t, err.Error(), "Cannot parse CA private key")
@@ -440,14 +558,16 @@ func TestCreateCert(t *testing.T) {
 				"foo.bar",
 			},
 			RoleName: "dummy-role",
+			CAName:   defaultCA,
 		}
 		secrets := &v1.Secret{Data: map[string][]byte{}}
 
-		newCert, err := createCert(certInfo, "namespace", "cluster.domain", secrets, certID, 365)
+		newCert, err := createCert(certInfo, nil, "namespace", "cluster.domain", secrets, certID, 365, false)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, newCert.PrivateKey)
 		assert.NotEmpty(t, newCert.Certificate)
+		assert.Empty(t, newCert.CSRName)
 
 		certBlob, _ := pem.Decode(newCert.Certificate)
 		require.NotNil(t, certBlob, "Failed to decode certificate PEM block")
@@ -475,5 +595,142 @@ func TestCreateCert(t *testing.T) {
 		assert.NotContains(t, cert.DNSNames, "*.*.dummy-role-set")
 		assert.NotContains(t, cert.DNSNames, "*.*.dummy-role-set.namespace.svc")
 		assert.NotContains(t, cert.DNSNames, "*.*.dummy-role-set.namespace.svc.cluster.domain")
+	})
+
+	t.Run("Create a kube csr, without auto-approval", func(t *testing.T) {
+		t.Parallel()
+
+		certInfo := make(map[string]CertInfo)
+		certInfo[certID] = CertInfo{
+			PrivateKeyName:  "private-key",
+			CertificateName: "certificate-name",
+			SubjectNames:    []string{"subject-names"},
+			CAName:          "",
+		}
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+
+		var csri MockCertificateSigningRequestInterface
+		csri.On("Create", mock.AnythingOfType("*v1beta1.CertificateSigningRequest"))
+
+		newCert, err := createCert(certInfo, &csri, "namespace", "cluster.domain", secrets, certID, 365, false)
+		csri.AssertCalled(t, "Create", mock.Anything)
+
+		require.NoError(t, err)
+		assert.Equal(t, newCert.CSRName, "namespace-"+certID)
+	})
+
+	t.Run("Create a kube csr, with auto-approval", func(t *testing.T) {
+		t.Parallel()
+
+		certInfo := make(map[string]CertInfo)
+		certInfo[certID] = CertInfo{
+			PrivateKeyName:  "private-key",
+			CertificateName: "certificate-name",
+			SubjectNames:    []string{"subject-names"},
+			CAName:          "",
+		}
+		secrets := &v1.Secret{Data: map[string][]byte{}}
+		csrName := "namespace-" + certID
+
+		var csri MockCertificateSigningRequestInterface
+		csri.On("Create", mock.AnythingOfType("*v1beta1.CertificateSigningRequest"))
+		csri.On("Get", csrName, metav1.GetOptions{})
+		csri.On("UpdateApproval", mock.AnythingOfType("*v1beta1.CertificateSigningRequest"))
+
+		newCert, err := createCert(certInfo, &csri, "namespace", "cluster.domain", secrets, certID, 365, true)
+		csri.AssertCalled(t, "Create", mock.Anything)
+		csri.AssertCalled(t, "Get", csrName, metav1.GetOptions{})
+		csri.AssertCalled(t, "UpdateApproval", mock.Anything)
+
+		require.NoError(t, err)
+		assert.Equal(t, newCert.CSRName, csrName)
+	})
+}
+
+func TestCreateKubeCSR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("createKubeCSR creates a new CSR and sets a normalized name", func(t *testing.T) {
+		t.Parallel()
+
+		var csri MockCertificateSigningRequestInterface
+		info := CertInfo{CAName: ""}
+		request := []byte("my-request")
+
+		csri.On("Create", mock.AnythingOfType("*v1beta1.CertificateSigningRequest"))
+
+		newCert, err := createKubeCSR(&csri, request, info, "namespace", "FOO_BAR", false)
+
+		csri.AssertCalled(t, "Create", mock.Anything)
+
+		require.NoError(t, err)
+		assert.Equal(t, newCert.CSRName, "namespace-foo-bar")
+	})
+}
+
+func TestApproveKubeCSR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("approveKubeCSR fetches the CSR and approves it", func(t *testing.T) {
+		t.Parallel()
+
+		var csri MockCertificateSigningRequestInterface
+		csri.On("Get", "foo", metav1.GetOptions{})
+		csri.On("UpdateApproval", mock.AnythingOfType("*v1beta1.CertificateSigningRequest"))
+
+		approveKubeCSR(&csri, "foo")
+
+		csri.AssertCalled(t, "Get", "foo", metav1.GetOptions{})
+		csri.AssertCalled(t, "UpdateApproval", mock.Anything)
+	})
+}
+
+func TestWaitForKubeCSR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("waitForKubeCSR repeatedly fetches the CSR until it is approved", func(t *testing.T) {
+		t.Parallel()
+
+		var csri MockCertificateSigningRequestInterface
+		info := CertInfo{CSRName: string(certificates.CertificateApproved)}
+
+		csri.On("Get", info.CSRName, metav1.GetOptions{})
+
+		newCert, err := waitForKubeCSR(&csri, info)
+
+		csri.AssertCalled(t, "Get", info.CSRName, metav1.GetOptions{})
+
+		require.NoError(t, err)
+		assert.Equal(t, newCert.Certificate, []byte("shiny"))
+	})
+
+	t.Run("waitForKubeCSR repeatedly fetches the CSR until it is denied", func(t *testing.T) {
+		t.Parallel()
+
+		var csri MockCertificateSigningRequestInterface
+		info := CertInfo{CSRName: string(certificates.CertificateDenied)}
+
+		csri.On("Get", info.CSRName, metav1.GetOptions{})
+
+		_, err := waitForKubeCSR(&csri, info)
+
+		csri.AssertCalled(t, "Get", info.CSRName, metav1.GetOptions{})
+
+		assert.EqualError(t, err, "kube csr Denied failed, condition is Denied, reason: because, why not?, message: Seriously!")
+	})
+
+	t.Run("waitForKubeCSR returns an error if the CSR cannot be found", func(t *testing.T) {
+		t.Parallel()
+
+		var csri MockCertificateSigningRequestInterface
+		info := CertInfo{CSRName: "Failed"}
+
+		csri.On("Get", info.CSRName, metav1.GetOptions{})
+
+		_, err := waitForKubeCSR(&csri, info)
+
+		csri.AssertCalled(t, "Get", info.CSRName, metav1.GetOptions{})
+
+		assert.EqualError(t, err, "fetching kube csr Failed returned error Something went wrong")
 	})
 }

--- a/ssl/testdata/kubeca.crt
+++ b/ssl/testdata/kubeca.crt
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+ThisIsJustTestData
+-----END CERTIFICATE-----

--- a/util/kube.go
+++ b/util/kube.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	certificates "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CertificateSigningRequestInterface is a subset of certificate.CertificateSigningRequestInterface
+type CertificateSigningRequestInterface interface {
+	Create(*certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error)
+	Delete(name string, options *metav1.DeleteOptions) error
+	Get(name string, options metav1.GetOptions) (*certificates.CertificateSigningRequest, error)
+	UpdateApproval(*certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error)
+}


### PR DESCRIPTION
When the `ca` field for an ssl cert definition is empty, create a kube CSR instead.

If the `-autoApprove` commandline option is set, then also attempt to approve the request.

The secrets generator will wait until all kube CSRs have been approved. Failure to auto-approve are ignored, but any errors while checking the status of pending CSRs will terminate the generator with an error.

Add `append_kube_ca` property to CA cert options. When `true`, the secrets generator will append the `ca.crt` from the kube service account to the CA cert generated for this variable.

Allow template expansion for all variable options. Previously this was hardcoded for the `alternative_names` list only, but now is available anywhere under the `options` key.

In addition this commit adds a `--set` commandline option to specify additional template environment variables.

Unrelated, this commit also removes the `common_name` setting, which is not used anywhere in the cert generation code.