### PR TITLE
Reduce RSA key size to 2048

### DIFF
--- a/ssl/ssl.go
+++ b/ssl/ssl.go
@@ -189,7 +189,7 @@ func GenerateCerts(certInfo map[string]CertInfo, csri util.CertificateSigningReq
 }
 
 func rsaKeyRequest() *csr.BasicKeyRequest {
-	return &csr.BasicKeyRequest{A: "rsa", S: 4096}
+	return &csr.BasicKeyRequest{A: "rsa", S: 2048}
 }
 
 func createCA(certInfo map[string]CertInfo, secrets *v1.Secret, id string, expiration int) error {

--- a/ssl/ssl_test.go
+++ b/ssl/ssl_test.go
@@ -362,7 +362,7 @@ func TestRsaKeyRequest(t *testing.T) {
 	t.Parallel()
 
 	kr := rsaKeyRequest()
-	assert.Equal(t, 4096, kr.S)
+	assert.Equal(t, 2048, kr.S)
 }
 
 func TestCreateCA(t *testing.T) {


### PR DESCRIPTION
According to RSA 2048 bit keys should remain good enough until 2030.

See also https://github.com/cloudfoundry-incubator/cf-operator/pull/695

Related to [jsc#CAP-150]